### PR TITLE
accumulated changes over the years of (almost) daily usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ iptraf-h += src/counters.h
 iptraf-h += src/rate.h
 iptraf-h += src/built-in.h
 iptraf-h += src/sockaddr.h
+iptraf-h += src/capt.h
+iptraf-h += src/capt-recvmsg.h
 
 iptraf-o += src/tui/input.o
 iptraf-o += src/tui/labels.o
@@ -157,6 +159,8 @@ iptraf-o += src/counters.o
 iptraf-o += src/rate.o
 iptraf-o += src/capture-pkt.o
 iptraf-o += src/sockaddr.o
+iptraf-o += src/capt.o
+iptraf-o += src/capt-recvmsg.o
 
 rvnamed-o += src/rvnamed.o
 rvnamed-o += src/getpath.o

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ iptraf-h += src/capt.h
 iptraf-h += src/capt-recvmsg.h
 iptraf-h += src/capt-recvmmsg.h
 iptraf-h += src/capt-mmap-v2.h
+iptraf-h += src/capt-mmap-v3.h
 
 iptraf-o += src/tui/input.o
 iptraf-o += src/tui/labels.o
@@ -165,6 +166,7 @@ iptraf-o += src/capt.o
 iptraf-o += src/capt-recvmsg.o
 iptraf-o += src/capt-recvmmsg.o
 iptraf-o += src/capt-mmap-v2.o
+iptraf-o += src/capt-mmap-v3.o
 
 rvnamed-o += src/rvnamed.o
 rvnamed-o += src/getpath.o

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERSION-FILE: FORCE
 	@$(SHELL_PATH) ./GEN-VERSION-FILE
 -include VERSION-FILE
 
-CFLAGS = -g -O2 -Wall -W -std=gnu99 -Werror=format-security
+CFLAGS = -g -O2 -Wall -W -std=gnu99 -Werror=format-security -D_GNU_SOURCE
 LDFLAGS =
 ALL_CFLAGS = $(CPPFLAGS) $(CFLAGS)
 ALL_LDFLAGS = $(LDFLAGS)
@@ -117,6 +117,7 @@ iptraf-h += src/built-in.h
 iptraf-h += src/sockaddr.h
 iptraf-h += src/capt.h
 iptraf-h += src/capt-recvmsg.h
+iptraf-h += src/capt-recvmmsg.h
 
 iptraf-o += src/tui/input.o
 iptraf-o += src/tui/labels.o
@@ -161,6 +162,7 @@ iptraf-o += src/capture-pkt.o
 iptraf-o += src/sockaddr.o
 iptraf-o += src/capt.o
 iptraf-o += src/capt-recvmsg.o
+iptraf-o += src/capt-recvmmsg.o
 
 rvnamed-o += src/rvnamed.o
 rvnamed-o += src/getpath.o

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ iptraf-h += src/sockaddr.h
 iptraf-h += src/capt.h
 iptraf-h += src/capt-recvmsg.h
 iptraf-h += src/capt-recvmmsg.h
+iptraf-h += src/capt-mmap-v2.h
 
 iptraf-o += src/tui/input.o
 iptraf-o += src/tui/labels.o
@@ -163,6 +164,7 @@ iptraf-o += src/sockaddr.o
 iptraf-o += src/capt.o
 iptraf-o += src/capt-recvmsg.o
 iptraf-o += src/capt-recvmmsg.o
+iptraf-o += src/capt-mmap-v2.o
 
 rvnamed-o += src/rvnamed.o
 rvnamed-o += src/getpath.o

--- a/src/capt-mmap-v2.c
+++ b/src/capt-mmap-v2.c
@@ -83,6 +83,7 @@ static void capt_cleanup_mmap_v2(struct capt *capt)
 	free(data->hdr);
 	data->hdr = NULL;
 
+	munlock(data->mmap, data->mmap_size);
 	munmap(data->mmap, data->mmap_size);
 	data->mmap = NULL;
 	data->mmap_size = 0;
@@ -116,6 +117,11 @@ int capt_setup_mmap_v2(struct capt *capt)
 	void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, capt->fd, 0);
 	if (map == MAP_FAILED)
 		return -1;
+
+	if(mlock(map, size) != 0) {
+		munmap(map, size);
+		return -1;
+	}
 
 	struct capt_data_mmap_v2 *data = xmallocz(sizeof(struct capt_data_mmap_v2));
 

--- a/src/capt-mmap-v2.c
+++ b/src/capt-mmap-v2.c
@@ -1,0 +1,140 @@
+/* For terms of usage/redistribution/modification see the LICENSE file */
+/* For authors and contributors see the AUTHORS file */
+
+#include "iptraf-ng-compat.h"
+
+#include "packet.h"
+#include "capt.h"
+
+struct capt_data_mmap_v2 {
+	void			*mmap;
+	size_t			mmap_size;
+	struct tpacket2_hdr	**hdr;
+	struct sockaddr_ll	**sll;
+	unsigned int		lastslot;
+	unsigned int		slot;
+};
+
+#define FRAMES 512
+#define FRAME_SIZE TPACKET_ALIGN(MAX_PACKET_SIZE + TPACKET_HDRLEN)
+
+static unsigned int capt_mmap_find_filled_slot(struct capt_data_mmap_v2 *data)
+{
+	for (unsigned int i = data->lastslot; i < data->lastslot + FRAMES; i++) {
+		unsigned int slot = i >= FRAMES ? i - FRAMES : i;
+
+		if (data->hdr[slot]->tp_status & TP_STATUS_USER)
+			return slot;
+	}
+	return FRAMES;
+}
+
+static unsigned int capt_have_packet_mmap_v2(struct capt *capt)
+{
+	struct capt_data_mmap_v2 *data = capt->priv;
+
+	return capt_mmap_find_filled_slot(data) != FRAMES;
+}
+
+static int capt_get_packet_mmap_v2(struct capt *capt, struct pkt_hdr *pkt)
+{
+	struct capt_data_mmap_v2 *data = capt->priv;
+	int ss = 0;
+
+	unsigned int slot = capt_mmap_find_filled_slot(data);
+	if (slot < FRAMES) {
+		struct tpacket2_hdr *hdr = data->hdr[slot];
+		struct sockaddr_ll *sll = data->sll[slot];
+
+		pkt->pkt_buf = (char *)hdr + hdr->tp_mac;
+		pkt->pkt_payload = NULL;
+		pkt->pkt_caplen = hdr->tp_snaplen;
+		pkt->pkt_len = hdr->tp_len;
+		pkt->from = sll;
+		pkt->pkt_protocol = ntohs(sll->sll_protocol);
+
+		data->slot = slot;
+		ss = hdr->tp_len;
+	}
+	return ss;
+}
+
+static int capt_put_packet_mmap_v2(struct capt *capt, struct pkt_hdr *pkt __unused)
+{
+	struct capt_data_mmap_v2 *data = capt->priv;
+
+	/* hand out processed slot to kernel */
+	if (data->slot < FRAMES) {
+		data->hdr[data->slot]->tp_status = TP_STATUS_KERNEL;
+		data->lastslot = data->slot;
+	} else
+		data->slot = FRAMES;
+
+	return 0;
+}
+
+static void capt_cleanup_mmap_v2(struct capt *capt)
+{
+	struct capt_data_mmap_v2 *data = capt->priv;
+
+	free(data->sll);
+	data->sll = NULL;
+
+	free(data->hdr);
+	data->hdr = NULL;
+
+	munmap(data->mmap, data->mmap_size);
+	data->mmap = NULL;
+	data->mmap_size = 0;
+
+	free(capt->priv);
+	capt->priv = NULL;
+}
+
+int capt_setup_mmap_v2(struct capt *capt)
+{
+	int version = TPACKET_V2;
+	if (setsockopt(capt->fd, SOL_PACKET, PACKET_VERSION, &version, sizeof(version)) != 0)
+		return -1;
+
+	int hdrlen = version;
+	socklen_t socklen = sizeof(hdrlen);
+	if (getsockopt(capt->fd, SOL_PACKET, PACKET_HDRLEN, &hdrlen, &socklen) != 0)
+		return -1;
+
+	struct tpacket_req req;
+
+	req.tp_block_nr = 1;	/* TODO: number of CPUs */
+	req.tp_frame_nr = FRAMES;
+	req.tp_frame_size = FRAME_SIZE;
+	req.tp_block_size = req.tp_frame_nr * req.tp_frame_size;
+
+	if(setsockopt(capt->fd, SOL_PACKET, PACKET_RX_RING, &req, sizeof(req)) != 0)
+		return -1;
+
+	size_t size = req.tp_block_size * req.tp_block_nr;
+	void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, capt->fd, 0);
+	if (map == MAP_FAILED)
+		return -1;
+
+	struct capt_data_mmap_v2 *data = xmallocz(sizeof(struct capt_data_mmap_v2));
+
+	data->mmap = map;
+	data->mmap_size = size;
+	data->hdr = xmallocz(FRAMES * sizeof(*data->hdr));
+	data->sll = xmallocz(FRAMES * sizeof(*data->sll));
+	for (int i = 0; i < FRAMES; i++) {
+		data->hdr[i] = (struct tpacket2_hdr *)((char *)map + i * FRAME_SIZE);
+		data->sll[i] = (struct sockaddr_ll *)((char *)data->hdr[i] + TPACKET_ALIGN(hdrlen));
+	}
+	data->lastslot = 0;
+	data->slot = FRAMES;
+
+	capt->priv		= data;
+	capt->have_packet	= capt_have_packet_mmap_v2;
+	capt->get_packet	= capt_get_packet_mmap_v2;
+	capt->put_packet	= capt_put_packet_mmap_v2;
+	capt->cleanup		= capt_cleanup_mmap_v2;
+
+	return 0;	/* All O.K. */
+}

--- a/src/capt-mmap-v2.h
+++ b/src/capt-mmap-v2.h
@@ -1,0 +1,6 @@
+#ifndef IPTRAF_NG_CAPT_MMAP_V2_H
+#define IPTRAF_NG_CAPT_MMAP_V2_H
+
+int capt_setup_mmap_v2(struct capt *capt);
+
+#endif	/* IPTRAF_NG_CAPT_MMAP_V2_H */

--- a/src/capt-mmap-v3.c
+++ b/src/capt-mmap-v3.c
@@ -1,0 +1,161 @@
+/* For terms of usage/redistribution/modification see the LICENSE file */
+/* For authors and contributors see the AUTHORS file */
+
+#include "iptraf-ng-compat.h"
+
+#include "packet.h"
+#include "capt.h"
+
+struct capt_data_mmap_v3 {
+	void				*mmap;
+	size_t				mmap_size;
+	int				hdrlen;
+	struct tpacket_block_desc	**pbds;
+	struct tpacket_block_desc	*pbd;
+	struct tpacket3_hdr		*ppd;
+	unsigned int			curblock;
+	unsigned int			lastblock;
+
+	uint32_t			num_pkts;	/* only for debug */
+	uint32_t			cur_pkt;	/* only for debug */
+};
+
+#define BLOCKS 32				/* 32 blocks / 256 frames in each block */
+#define FRAMES_PER_BLOCK 256
+#define FRAMES (BLOCKS * FRAMES_PER_BLOCK)	/* frames over all blocks */
+#define FRAME_SIZE TPACKET_ALIGN(MAX_PACKET_SIZE + TPACKET_HDRLEN)
+
+static struct tpacket_block_desc *capt_mmap_find_filled_block(struct capt_data_mmap_v3 *data)
+{
+	for (unsigned int i = data->lastblock; i < data->lastblock + BLOCKS; i++) {
+		unsigned int block = i >= BLOCKS ? i - BLOCKS : i;
+
+		if (data->pbds[block]->hdr.bh1.block_status & TP_STATUS_USER) {
+			data->curblock = block;
+			return data->pbds[block];
+		}
+	}
+	return NULL;
+}
+
+static unsigned int capt_have_packet_mmap_v3(struct capt *capt)
+{
+	struct capt_data_mmap_v3 *data = capt->priv;
+
+	if (data->pbd != NULL)
+		return true;
+
+	data->pbd = capt_mmap_find_filled_block(data);
+	if (data->pbd != NULL)
+		return true;
+	else
+		return false;
+}
+
+static int capt_get_packet_mmap_v3(struct capt *capt, struct pkt_hdr *pkt)
+{
+	struct capt_data_mmap_v3 *data = capt->priv;
+
+	if (data->pbd == NULL)
+		data->pbd = capt_mmap_find_filled_block(data);
+
+	if (data->pbd == NULL)
+		return 0;	/* no packet ready */
+
+	if (data->ppd == NULL) {
+		data->ppd = (struct tpacket3_hdr *) ((uint8_t *)data->pbd + data->pbd->hdr.bh1.offset_to_first_pkt);
+		data->num_pkts = data->pbd->hdr.bh1.num_pkts;
+	}
+
+	/* here should be at least one packet ready */
+	pkt->pkt_buf = (char *)data->ppd + data->ppd->tp_mac;
+	pkt->pkt_payload = NULL;
+	pkt->pkt_len = data->ppd->tp_len;
+	pkt->from = (struct sockaddr_ll *)((uint8_t *)data->ppd + data->hdrlen);
+	pkt->pkt_protocol = ntohs(pkt->from->sll_protocol);
+
+	return pkt->pkt_len;
+}
+
+static int capt_put_packet_mmap_v3(struct capt *capt, struct pkt_hdr *pkt __unused)
+{
+	struct capt_data_mmap_v3 *data = capt->priv;
+
+	if (data->ppd->tp_next_offset != 0) {
+		data->ppd = (struct tpacket3_hdr *)((uint8_t *)data->ppd + data->ppd->tp_next_offset);
+		data->cur_pkt++;
+	} else {
+		data->ppd = NULL;
+		data->num_pkts = 0;
+		data->cur_pkt = 0;
+		data->pbd->hdr.bh1.block_status = TP_STATUS_KERNEL;
+		data->pbd = NULL;
+		data->lastblock = data->curblock;
+	}
+
+	return 0;
+}
+
+static void capt_cleanup_mmap_v3(struct capt *capt)
+{
+	struct capt_data_mmap_v3 *data = capt->priv;
+
+	free(data->pbds);
+	munmap(data->mmap, data->mmap_size);
+
+	memset(data, 0, sizeof(*data));
+
+	free(capt->priv);
+	capt->priv = NULL;
+}
+
+int capt_setup_mmap_v3(struct capt *capt)
+{
+	int version = TPACKET_V3;
+	if (setsockopt(capt->fd, SOL_PACKET, PACKET_VERSION, &version, sizeof(version)) != 0)
+		return -1;
+
+	int hdrlen = version;
+	socklen_t socklen = sizeof(hdrlen);
+	if (getsockopt(capt->fd, SOL_PACKET, PACKET_HDRLEN, &hdrlen, &socklen) != 0)
+		return -1;
+
+	struct tpacket_req3 req;
+
+	req.tp_block_nr = BLOCKS;
+	req.tp_frame_nr = FRAMES;
+	req.tp_frame_size = FRAME_SIZE;
+	req.tp_block_size = FRAMES_PER_BLOCK * req.tp_frame_size;
+
+	req.tp_retire_blk_tov = 20;	/* block retire timeout in msec */
+	req.tp_sizeof_priv = 0;
+	// req.tp_feature_req_word = TP_FT_REQ_FILL_RXHASH;
+
+	if(setsockopt(capt->fd, SOL_PACKET, PACKET_RX_RING, &req, sizeof(req)) != 0)
+		return -1;
+
+	size_t size = req.tp_block_size * req.tp_block_nr;
+	void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, capt->fd, 0);
+	if (map == MAP_FAILED)
+		return -1;
+	/* mlock() ??? */
+
+	struct capt_data_mmap_v3 *data = xmallocz(sizeof(struct capt_data_mmap_v3));
+
+	data->hdrlen = hdrlen;
+	data->mmap = map;
+	data->mmap_size = size;
+
+	data->pbds = xmallocz(BLOCKS * sizeof(*data->pbd));
+	for (int i = 0; i < BLOCKS; i++) {
+		data->pbds[i] = map + i * req.tp_block_size;
+	}
+
+	capt->priv		= data;
+	capt->have_packet	= capt_have_packet_mmap_v3;
+	capt->get_packet	= capt_get_packet_mmap_v3;
+	capt->put_packet	= capt_put_packet_mmap_v3;
+	capt->cleanup		= capt_cleanup_mmap_v3;
+
+	return 0;	/* All O.K. */
+}

--- a/src/capt-mmap-v3.c
+++ b/src/capt-mmap-v3.c
@@ -20,9 +20,15 @@ struct capt_data_mmap_v3 {
 	uint32_t			cur_pkt;	/* only for debug */
 };
 
-#define BLOCKS 32				/* 32 blocks / 256 frames in each block */
-#define FRAMES_PER_BLOCK 256
+#define BLOCKS 256		/* 256 blocks / 512 frames in each block:
+				 *   this gets room for 128k packets, which
+				 *   "should be enough for everybody" ;-) */
+
+#define FRAMES_PER_BLOCK 512	/* keep it as power-of-two (dramaticly lowers
+				 * CPU utilization) */
+
 #define FRAMES (BLOCKS * FRAMES_PER_BLOCK)	/* frames over all blocks */
+
 #define FRAME_SIZE TPACKET_ALIGN(MAX_PACKET_SIZE + TPACKET_HDRLEN)
 
 static struct tpacket_block_desc *capt_mmap_find_filled_block(struct capt_data_mmap_v3 *data)

--- a/src/capt-mmap-v3.h
+++ b/src/capt-mmap-v3.h
@@ -1,0 +1,6 @@
+#ifndef IPTRAF_NG_CAPT_MMAP_V3_H
+#define IPTRAF_NG_CAPT_MMAP_V3_H
+
+int capt_setup_mmap_v3(struct capt *capt);
+
+#endif	/* IPTRAF_NG_CAPT_MMAP_V3_H */

--- a/src/capt-recvmmsg.c
+++ b/src/capt-recvmmsg.c
@@ -1,0 +1,138 @@
+/* For terms of usage/redistribution/modification see the LICENSE file */
+/* For authors and contributors see the AUTHORS file */
+
+#include "iptraf-ng-compat.h"
+
+#include "packet.h"
+#include "capt.h"
+
+#define FRAMES 128
+
+struct capt_data_recvmmsg {
+	char			*buf;
+
+	struct mmsghdr		*msgvec;
+	struct iovec		*iov;
+	struct sockaddr_ll	*from;
+
+	unsigned int		lastslot;
+	unsigned int		slot;
+};
+
+static unsigned int capt_recvmmsg_find_filled_slot(struct capt_data_recvmmsg *data)
+{
+	for (unsigned int slot = data->lastslot; slot < FRAMES; slot++)
+		if (data->msgvec[slot].msg_len != 0)
+			return slot;
+
+	return FRAMES;
+}
+
+static unsigned int capt_have_packet_recvmmsg(struct capt *capt)
+{
+	struct capt_data_recvmmsg *data = capt->priv;
+
+	return capt_recvmmsg_find_filled_slot(data) != FRAMES;
+}
+
+static int capt_get_packet_recvmmsg(struct capt *capt, struct pkt_hdr *pkt)
+{
+	struct capt_data_recvmmsg *data = capt->priv;
+	int ret = 0;
+
+	unsigned int slot = capt_recvmmsg_find_filled_slot(data);
+	if (slot == FRAMES) {
+		/* these are set upon return from recvmsg() so clean */
+		/* them beforehand */
+		for (unsigned int i = 0; i < FRAMES; i++) {
+			data->msgvec[i].msg_hdr.msg_controllen = 0;
+			data->msgvec[i].msg_hdr.msg_flags = 0;
+			data->msgvec[i].msg_len = 0;
+		}
+
+		int received = recvmmsg(capt->fd, data->msgvec, FRAMES, MSG_TRUNC | MSG_DONTWAIT, NULL);
+		if (received <= 0)
+			return received;
+		slot = 0;
+	}
+	pkt->pkt_len = data->msgvec[slot].msg_len;
+	pkt->pkt_caplen = data->msgvec[slot].msg_len;
+	if (pkt->pkt_caplen > MAX_PACKET_SIZE)
+		pkt->pkt_caplen = MAX_PACKET_SIZE;
+	pkt->pkt_buf = data->buf + slot * MAX_PACKET_SIZE;
+	pkt->from = &data->from[slot];
+	pkt->pkt_payload = NULL;
+	pkt->pkt_protocol = ntohs(pkt->from->sll_protocol);
+
+	data->slot = slot;
+
+	return ret;
+}
+
+static int capt_put_packet_recvmmsg(struct capt *capt, struct pkt_hdr *pkt __unused)
+{
+	struct capt_data_recvmmsg *data = capt->priv;
+
+	/* hand out processed slot to kernel */
+	if (data->slot < FRAMES) {
+		data->msgvec[data->slot].msg_len = 0;
+		data->lastslot = data->slot;
+	} else
+		data->slot = FRAMES;
+
+	return 0;
+}
+
+static void capt_cleanup_recvmmsg(struct capt *capt)
+{
+	struct capt_data_recvmmsg *data = capt->priv;
+
+	capt->cleanup = NULL;
+	capt->put_packet = NULL;
+	capt->get_packet = NULL;
+	capt->have_packet = NULL;
+
+	free(data->from);
+	data->from = NULL;
+	free(data->iov);
+	data->iov = NULL;
+	free(data->msgvec);
+	data->msgvec = NULL;
+	free(data->buf);
+	data->buf = NULL;
+
+	free(capt->priv);
+	capt->priv = NULL;
+}
+
+int capt_setup_recvmmsg(struct capt *capt)
+{
+	struct capt_data_recvmmsg *data;
+
+	data			= xmallocz(sizeof(struct capt_data_recvmmsg));
+	data->buf		= xmallocz(FRAMES * MAX_PACKET_SIZE);
+	data->msgvec		= xmallocz(FRAMES * sizeof(*data->msgvec));
+	data->iov		= xmallocz(FRAMES * sizeof(*data->iov));
+	data->from		= xmallocz(FRAMES * sizeof(*data->from));
+
+	for (unsigned int i = 0; i < FRAMES; i++) {
+		data->iov[i].iov_len	= MAX_PACKET_SIZE;
+		data->iov[i].iov_base	= data->buf + i * MAX_PACKET_SIZE;
+
+		data->msgvec[i].msg_hdr.msg_name	= &data->from[i];
+		data->msgvec[i].msg_hdr.msg_namelen	= sizeof(data->from[i]);
+		data->msgvec[i].msg_hdr.msg_iov		= &data->iov[i];
+		data->msgvec[i].msg_hdr.msg_iovlen	= 1;
+		data->msgvec[i].msg_hdr.msg_control	= NULL;
+	}
+	data->slot = FRAMES;
+	data->lastslot = 0;
+
+	capt->priv		= data;
+	capt->have_packet	= capt_have_packet_recvmmsg;
+	capt->get_packet	= capt_get_packet_recvmmsg;
+	capt->put_packet	= capt_put_packet_recvmmsg;
+	capt->cleanup		= capt_cleanup_recvmmsg;
+
+	return 0;
+}

--- a/src/capt-recvmmsg.h
+++ b/src/capt-recvmmsg.h
@@ -1,0 +1,6 @@
+#ifndef IPTRAF_NG_CAPT_RECVMMSG_H
+#define IPTRAF_NG_CAPT_RECVMMSG_H
+
+int capt_setup_recvmmsg(struct capt *capt);
+
+#endif	/* IPTRAF_NG_CAPT_RECVMMSG_H */

--- a/src/capt-recvmsg.c
+++ b/src/capt-recvmsg.c
@@ -1,0 +1,89 @@
+/* For terms of usage/redistribution/modification see the LICENSE file */
+/* For authors and contributors see the AUTHORS file */
+
+#include "iptraf-ng-compat.h"
+
+#include "packet.h"
+#include "capt.h"
+
+struct capt_data_recvmsg {
+	char			*buf;
+
+	struct iovec		iov;
+	struct msghdr		*msg;
+	struct sockaddr_ll	*from;
+};
+
+static unsigned int capt_have_packet_recvmsg(struct capt *capt __unused)
+{
+	return 0;
+}
+
+static int capt_get_packet_recvmsg(struct capt *capt, struct pkt_hdr *pkt)
+{
+	struct capt_data_recvmsg *data = capt->priv;
+
+	/* these are set upon return from recvmsg() so clean */
+	/* them beforehand */
+	data->msg->msg_controllen = 0;
+	data->msg->msg_flags = 0;
+
+	ssize_t len = recvmsg(capt->fd, data->msg, MSG_TRUNC | MSG_DONTWAIT);
+	if (len > 0) {
+		pkt->pkt_len = len;
+		pkt->pkt_caplen = len;
+		if (pkt->pkt_caplen > MAX_PACKET_SIZE)
+			pkt->pkt_caplen = MAX_PACKET_SIZE;
+		pkt->pkt_buf = data->buf;
+		pkt->from = data->from;
+		pkt->pkt_payload = NULL;
+		pkt->pkt_protocol = ntohs(pkt->from->sll_protocol);
+	}
+	return len;
+}
+
+static void capt_cleanup_recvmsg(struct capt *capt)
+{
+	struct capt_data_recvmsg *data = capt->priv;
+
+	capt->cleanup = NULL;
+	capt->put_packet = NULL;
+	capt->get_packet = NULL;
+	capt->have_packet = NULL;
+
+	free(data->from);
+	data->from = NULL;
+	free(data->msg);
+	data->msg = NULL;
+
+	free(data->buf);
+	data->buf = NULL;
+	free(capt->priv);
+	capt->priv = NULL;
+}
+
+int capt_setup_recvmsg(struct capt *capt)
+{
+	struct capt_data_recvmsg *data = xmallocz(sizeof(struct capt_data_recvmsg));
+
+	data->buf		= xmallocz(MAX_PACKET_SIZE);
+	data->iov.iov_len	= MAX_PACKET_SIZE;
+	data->iov.iov_base	= data->buf;
+
+	data->msg		= xmallocz(sizeof(*data->msg));
+	data->from		= xmallocz(sizeof(*data->from));
+
+	data->msg->msg_name	= data->from;
+	data->msg->msg_namelen	= sizeof(*data->from);
+	data->msg->msg_iov	= &data->iov;
+	data->msg->msg_iovlen	= 1;
+	data->msg->msg_control	= NULL;
+
+	capt->priv		= data;
+	capt->have_packet	= capt_have_packet_recvmsg;
+	capt->get_packet	= capt_get_packet_recvmsg;
+	capt->put_packet	= NULL;
+	capt->cleanup		= capt_cleanup_recvmsg;
+
+	return 0;
+}

--- a/src/capt-recvmsg.h
+++ b/src/capt-recvmsg.h
@@ -1,0 +1,6 @@
+#ifndef IPTRAF_NG_CAPT_RECVMSG_H
+#define IPTRAF_NG_CAPT_RECVMSG_H
+
+int capt_setup_recvmsg(struct capt *capt);
+
+#endif	/* IPTRAF_NG_CAPT_RECVMSG_H */

--- a/src/capt.c
+++ b/src/capt.c
@@ -9,6 +9,7 @@
 #include "capt.h"
 #include "capt-recvmsg.h"
 #include "capt-recvmmsg.h"
+#include "capt-mmap-v2.h"
 
 static int capt_set_recv_timeout(int fd, unsigned int msec)
 {
@@ -45,6 +46,10 @@ int capt_init(struct capt *capt, char *ifname)
 	/* set socket receive timeout */
 	if (capt_set_recv_timeout(capt->fd, 250) == -1)
 		goto out;
+
+	/* try packet mmap() TPACKET_V2 */
+	if (capt_setup_mmap_v2(capt) == 0)
+		return 0;
 
 	/* try packet recvmmsg() */
 	if (capt_setup_recvmmsg(capt) == 0)

--- a/src/capt.c
+++ b/src/capt.c
@@ -10,6 +10,7 @@
 #include "capt-recvmsg.h"
 #include "capt-recvmmsg.h"
 #include "capt-mmap-v2.h"
+#include "capt-mmap-v3.h"
 
 static int capt_set_recv_timeout(int fd, unsigned int msec)
 {
@@ -26,6 +27,10 @@ static int capt_set_recv_timeout(int fd, unsigned int msec)
 
 static int capt_setup_receive_function(struct capt *capt)
 {
+	/* try packet mmap() TPACKET_V3 */
+	if (capt_setup_mmap_v3(capt) == 0)
+		return 0;
+
 	/* try packet mmap() TPACKET_V2 */
 	if (capt_setup_mmap_v2(capt) == 0)
 		return 0;

--- a/src/capt.c
+++ b/src/capt.c
@@ -1,0 +1,139 @@
+/* For terms of usage/redistribution/modification see the LICENSE file */
+/* For authors and contributors see the AUTHORS file */
+
+#include "iptraf-ng-compat.h"
+
+#include "error.h"
+#include "ifaces.h"
+#include "packet.h"
+#include "capt.h"
+#include "capt-recvmsg.h"
+
+static int capt_set_recv_timeout(int fd, unsigned int msec)
+{
+	struct timeval timeout;
+	socklen_t len = sizeof(timeout);
+
+	timeout.tv_sec = msec / 1000;
+	timeout.tv_usec = (msec % 1000) * 1000;
+	if(setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, len) != 0)
+		return -1;
+	else
+		return 0;
+}
+
+int capt_init(struct capt *capt, char *ifname)
+{
+	capt->have_packet = NULL;
+	capt->get_packet = NULL;
+	capt->put_packet = NULL;
+	capt->cleanup = NULL;
+
+	capt->dropped = 0UL;
+
+	/* initialize socket */
+	int fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+	if (fd == -1)
+		return fd;
+	capt->fd = fd;
+
+	/* bind socket to interface */
+	if (ifname && dev_bind_ifname(capt->fd, ifname) == -1)
+		goto out;
+
+	/* set socket receive timeout */
+	if (capt_set_recv_timeout(capt->fd, 250) == -1)
+		goto out;
+
+	/* try packet recvmsg() */
+	if (capt_setup_recvmsg(capt) == 0)
+		return 0;
+out:
+	close(capt->fd);
+	capt->fd = -1;
+
+	return -1;
+}
+
+void capt_destroy(struct capt *capt)
+{
+	if (capt->cleanup)
+		capt->cleanup(capt);
+
+	close(capt->fd);
+	capt->fd = -1;
+}
+
+unsigned long capt_get_dropped(struct capt *capt)
+{
+	struct tpacket_stats stats;
+	socklen_t len = sizeof(stats);
+
+	memset(&stats, 0, len);
+	int err = getsockopt(capt->fd, SOL_PACKET, PACKET_STATISTICS, &stats, &len);
+	if (err < 0)
+		die_errno("%s(): getsockopt(PACKET_STATISTICS)", __func__);
+
+	capt->dropped += stats.tp_drops;
+
+	return capt->dropped;
+}
+
+int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win)
+{
+	struct pollfd pfds[2];
+	nfds_t nfds = 0;
+	int pfd_packet = -1;
+	int pfd_key = -1;
+	int ss = 0;
+	int poll_packet = !capt->have_packet(capt);
+	int timeout = DEFAULT_UPDATE_DELAY;
+
+	/* Monitor raw socket */
+	if (poll_packet) {
+		pfds[nfds].fd = capt->fd;
+		pfds[nfds].events = POLLIN;
+		pfd_packet = nfds;
+		nfds++;
+	}
+
+	/* Monitor stdin only if in interactive, not daemon mode. */
+	if (ch && !daemonized) {
+		pfds[nfds].fd = 0;
+		pfds[nfds].events = POLLIN;
+		pfd_key = nfds;
+		nfds++;
+		if (!poll_packet)
+			timeout = 0;
+	}
+
+	if (nfds > 0)
+		do {
+			ss = poll(pfds, nfds, timeout);
+		} while ((ss == -1) && (errno == EINTR));
+
+	/* no packet ready yet */
+	pkt->pkt_len = 0;
+
+	if (!poll_packet || ((pfd_packet != -1) && (ss > 0) && ((pfds[pfd_packet].revents & POLLIN) != 0))) {
+		int ret = capt->get_packet(capt, pkt);
+		if (ret <= 0)
+			ss = ret;
+	}
+
+	if (ch) {
+		*ch = ERR;	/* signalize we have no key ready */
+		if (!daemonized && (((pfd_key != -1) && ((ss > 0) && ((pfds[pfd_key].revents & POLLIN) != 0)))))
+			*ch = wgetch(win);
+	}
+
+	return ss;
+}
+
+int capt_put_packet(struct capt *capt, struct pkt_hdr *pkt)
+{
+	if (capt->put_packet)
+		capt->put_packet(capt, pkt);
+
+	return 0;
+}

--- a/src/capt.c
+++ b/src/capt.c
@@ -8,6 +8,7 @@
 #include "packet.h"
 #include "capt.h"
 #include "capt-recvmsg.h"
+#include "capt-recvmmsg.h"
 
 static int capt_set_recv_timeout(int fd, unsigned int msec)
 {
@@ -44,6 +45,10 @@ int capt_init(struct capt *capt, char *ifname)
 	/* set socket receive timeout */
 	if (capt_set_recv_timeout(capt->fd, 250) == -1)
 		goto out;
+
+	/* try packet recvmmsg() */
+	if (capt_setup_recvmmsg(capt) == 0)
+		return 0;
 
 	/* try packet recvmsg() */
 	if (capt_setup_recvmsg(capt) == 0)

--- a/src/capt.h
+++ b/src/capt.h
@@ -1,0 +1,31 @@
+#ifndef IPTRAF_NG_CAPT_H
+#define IPTRAF_NG_CAPT_H
+
+/*
+ * Number of bytes from captured packet to move into a buffer.
+ * 96 bytes should be enough for the IP header, TCP/UDP/ICMP/whatever header
+ * with reasonable numbers of options.
+ *
+ * keep it aligned to 16 !!!
+ */
+#define MAX_PACKET_SIZE 96
+
+struct capt {
+	int		fd;
+	unsigned long	dropped;
+
+	void		*priv;
+
+	unsigned int	(*have_packet)(struct capt *capt);
+	int		(*get_packet)(struct capt *capt, struct pkt_hdr *pkt);
+	int		(*put_packet)(struct capt *capt, struct pkt_hdr *pkt);
+	void		(*cleanup)(struct capt *capt);
+};
+
+int capt_init(struct capt *capt, char *ifname);
+void capt_destroy(struct capt *capt);
+unsigned long capt_get_dropped(struct capt *capt);
+int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win);
+int capt_put_packet(struct capt *capt, struct pkt_hdr *pkt);
+
+#endif	/* IPTRAF_NG_CAPT_H */

--- a/src/cidr.c
+++ b/src/cidr.c
@@ -55,31 +55,17 @@ unsigned int cidr_get_maskbits(unsigned long mask)
 }
 
 /*
- * Splits a CIDR-style address/mask string into its constituent address and
- * mask parts.  In case of absent or invalid input in the mask part, 255 is
- * returned in *maskbits (255 is invalid for an IPv4 address).
+ * Parse and cut off mask from CIDR-style address/mask string. In case of
+ * absent or invalid input in the mask, 255 is returned in *maskbits
+ * (255 is invalid for an IPv4 address).
  */
-void cidr_split_address(char *cidr_addr, char *addresspart,
-			unsigned int *maskbits)
+void cidr_split_address(char *cidr_addr, unsigned int *maskbits)
 {
-	char maskpart[4];
-	char *endptr;
-	char *slashptr;
-
-	char address_buffer[80];
-
-	if (strchr(cidr_addr, '/') == NULL) {
-		strncpy(addresspart, cidr_addr, 80);
+	char *slashptr = strchr(cidr_addr, '/');
+	if (slashptr == NULL) {
 		*maskbits = 255;
 		return;
 	}
-
-	memset(address_buffer, 0, sizeof(address_buffer));
-	memset(addresspart, 0, 80);
-	memset(maskpart, 0, sizeof(maskpart));
-
-	strncpy(address_buffer, cidr_addr, sizeof(address_buffer) - 1);
-	slashptr = strchr(address_buffer, '/');
 
 	/*
 	 * Cut out the mask part and move past the slash
@@ -87,14 +73,14 @@ void cidr_split_address(char *cidr_addr, char *addresspart,
 	*slashptr = '\0';
 	slashptr++;
 
-	/*
-	 * Copy out the address and mask parts into their buffers.
-	 */
-	strncpy(addresspart, address_buffer, 80);
-	strncpy(maskpart, slashptr, sizeof(maskpart) - 1);
+	if (*slashptr != '\0') {
+		unsigned long val;
+		char *endptr;
 
-	if (maskpart[0] != '\0') {
-		*maskbits = strtoul(maskpart, &endptr, 10);
+		val = strtoul(slashptr, &endptr, 10);
+		if (val > UINT_MAX)
+			val = UINT_MAX;
+		*maskbits = (unsigned int)val;
 		if (*endptr != '\0')
 			*maskbits = 255;
 	} else

--- a/src/cidr.c
+++ b/src/cidr.c
@@ -74,11 +74,11 @@ void cidr_split_address(char *cidr_addr, char *addresspart,
 		return;
 	}
 
-	memset(address_buffer, 0, 80);
+	memset(address_buffer, 0, sizeof(address_buffer));
 	memset(addresspart, 0, 80);
-	memset(maskpart, 0, 4);
+	memset(maskpart, 0, sizeof(maskpart));
 
-	strncpy(address_buffer, cidr_addr, 80);
+	strncpy(address_buffer, cidr_addr, sizeof(address_buffer) - 1);
 	slashptr = strchr(address_buffer, '/');
 
 	/*
@@ -91,7 +91,7 @@ void cidr_split_address(char *cidr_addr, char *addresspart,
 	 * Copy out the address and mask parts into their buffers.
 	 */
 	strncpy(addresspart, address_buffer, 80);
-	strncpy(maskpart, slashptr, 4);
+	strncpy(maskpart, slashptr, sizeof(maskpart) - 1);
 
 	if (maskpart[0] != '\0') {
 		*maskbits = strtoul(maskpart, &endptr, 10);

--- a/src/cidr.h
+++ b/src/cidr.h
@@ -4,7 +4,6 @@
 unsigned long cidr_get_mask(unsigned int maskbits);
 char *cidr_get_quad_mask(unsigned int maskbits);
 unsigned int cidr_get_maskbits(unsigned long mask);
-void cidr_split_address(char *cidr_addr, char *addresspart,
-			unsigned int *maskbits);
+void cidr_split_address(char *cidr_addr, unsigned int *maskbits);
 
 #endif	/* IPTRAF_NG_CIDR_H */

--- a/src/deskman.c
+++ b/src/deskman.c
@@ -193,7 +193,7 @@ void printlargenum(unsigned long long i, WINDOW * win)
 void print_packet_drops(unsigned long count, WINDOW *win, int x)
 {
 	wattrset(win, BOXATTR);
-	mvwprintw(win, getmaxy(win) - 1, x, " Dropped packets:  %lu ", count);
+	mvwprintw(win, getmaxy(win) - 1, x, " Drops: %9lu ", count);
 }
 
 int screen_update_needed(const struct timeval *now, const struct timeval *last)

--- a/src/ifaces.c
+++ b/src/ifaces.c
@@ -237,7 +237,7 @@ int dev_get_ifname(int ifindex, char *ifname)
 	return ir;
 }
 
-int dev_bind_ifindex(int fd, const int ifindex)
+static int dev_bind_ifindex(int fd, const int ifindex)
 {
 	struct sockaddr_ll fromaddr;
 	socklen_t addrlen = sizeof(fromaddr);

--- a/src/ifaces.c
+++ b/src/ifaces.c
@@ -250,15 +250,20 @@ int dev_bind_ifindex(int fd, const int ifindex)
 
 int dev_bind_ifname(int fd, const char * const ifname)
 {
-	int ir;
-	struct ifreq ifr;
+	int ifindex = 0;
 
-	strcpy(ifr.ifr_name, ifname);
-	ir = ioctl(fd, SIOCGIFINDEX, &ifr);
-	if (ir)
-		return ir;
+	if (ifname) {
+		int ir;
+		struct ifreq ifr;
 
-	return dev_bind_ifindex(fd, ifr.ifr_ifindex);
+		strcpy(ifr.ifr_name, ifname);
+		ir = ioctl(fd, SIOCGIFINDEX, &ifr);
+		if (ir)
+			return ir;
+		ifindex = ifr.ifr_ifindex;
+	}
+
+	return dev_bind_ifindex(fd, ifindex);
 }
 
 int dev_promisc_flag(const char *dev_name)

--- a/src/ifaces.c
+++ b/src/ifaces.c
@@ -261,19 +261,6 @@ int dev_bind_ifname(int fd, const char * const ifname)
 	return dev_bind_ifindex(fd, ifr.ifr_ifindex);
 }
 
-char *gen_iface_msg(char *ifptr)
-{
-	static char if_msg[20];
-
-	if (ifptr == NULL)
-		strcpy(if_msg, "all interfaces");
-	else
-		strncpy(if_msg, ifptr, 20);
-
-	return if_msg;
-}
-
-
 int dev_promisc_flag(const char *dev_name)
 {
 	int flags = dev_get_flags(dev_name);

--- a/src/ifaces.h
+++ b/src/ifaces.h
@@ -14,7 +14,6 @@ int dev_get_flags(const char *iface);
 int dev_set_flags(const char *iface, int flags);
 int dev_clear_flags(const char *iface, int flags);
 int dev_get_ifname(int ifindex, char *ifname);
-int dev_bind_ifindex(const int fd, const int ifindex);
 int dev_bind_ifname(const int fd, const char * const ifname);
 int dev_promisc_flag(const char *dev_name);
 

--- a/src/ifaces.h
+++ b/src/ifaces.h
@@ -16,7 +16,6 @@ int dev_clear_flags(const char *iface, int flags);
 int dev_get_ifname(int ifindex, char *ifname);
 int dev_bind_ifindex(const int fd, const int ifindex);
 int dev_bind_ifname(const int fd, const char * const ifname);
-char *gen_iface_msg(char *ifptr);
 int dev_promisc_flag(const char *dev_name);
 
 #endif	/* IPTRAF_NG_IFACES_H */

--- a/src/ifstats.c
+++ b/src/ifstats.c
@@ -30,6 +30,7 @@ ifstats.c	- the interface statistics module
 #include "ifstats.h"
 #include "rate.h"
 #include "capt.h"
+#include "counters.h"
 
 #define SCROLLUP 0
 #define SCROLLDOWN 1
@@ -56,6 +57,9 @@ struct iftab {
 	struct iflist *tail;
 	struct iflist *firstvisible;
 	struct iflist *lastvisible;
+	struct pkt_counter totals;
+	struct rate rate_total;
+	struct rate rate_totalpps;
 	WINDOW *borderwin;
 	PANEL *borderpanel;
 	WINDOW *statwin;
@@ -269,6 +273,9 @@ static void updaterates(struct iftab *table, unsigned long msecs)
 	struct iflist *ptmp = table->head;
 	unsigned long rate;
 
+	rate_add_rate(&table->rate_total, table->totals.pc_bytes, msecs);
+	rate_add_rate(&table->rate_totalpps, table->totals.pc_packets, msecs);
+	pkt_counter_reset(&table->totals);
 	while (ptmp != NULL) {
 		rate_add_rate(&ptmp->rate, ptmp->spanbr, msecs);
 		rate = rate_get_average(&ptmp->rate);
@@ -359,6 +366,10 @@ static void initiftab(struct iftab *table)
 {
 	table->borderwin = newwin(LINES - 2, COLS, 1, 0);
 	table->borderpanel = new_panel(table->borderwin);
+
+	rate_alloc(&table->rate_total, 5);
+	rate_alloc(&table->rate_totalpps, 5);
+	pkt_counter_reset(&table->totals);
 
 	move(LINES - 1, 1);
 	scrollkeyhelp();
@@ -473,6 +484,8 @@ static void ifstats_process_packet(struct iftab *table, struct pkt_hdr *pkt)
 	default:			/* drop others */
 		return;
 	}
+
+	pkt_counter_update(&table->totals, pkt->pkt_len);
 
 	struct iflist *ptmp = positionptr(table->head, pkt->from->sll_ifindex);
 	if (!ptmp)
@@ -591,7 +604,16 @@ void ifstats(time_t facilitytime)
 
 			printelapsedtime(now.tv_sec - starttime, 1, table.borderwin);
 
-			print_packet_drops(capt_get_dropped(&capt), table.borderwin, 49);
+			print_packet_drops(capt_get_dropped(&capt), table.borderwin, 61);
+
+			wattrset(table.borderwin, BOXATTR);
+			char buf[64];
+			rate_print(rate_get_average(&table.rate_total), buf, sizeof(buf));
+			mvwprintw(table.borderwin,
+				  getmaxy(table.borderwin) - 1, 19,
+				  " Total: %s / %9lu pps ",
+				  buf,
+				  rate_get_average(&table.rate_totalpps));
 
 			if (logging && (now.tv_sec > log_next)) {
 				check_rotate_flag(&logfile);
@@ -653,6 +675,8 @@ err:
 	doupdate();
 
 	destroyiflist(table.head);
+	rate_destroy(&table.rate_total);
+	rate_destroy(&table.rate_totalpps);
 }
 
 void selectiface(char *ifname, int withall, int *aborted)

--- a/src/ipfilter.c
+++ b/src/ipfilter.c
@@ -185,7 +185,8 @@ void gethostparams(struct hostparams *data, char *init_saddr, char *init_smask,
 				strcpy(data->s_mask, WILDCARD);
 			} else {
 				strncpy(data->s_mask,
-					cidr_get_quad_mask(maskbits), 20);
+					cidr_get_quad_mask(maskbits),
+					sizeof(data->s_mask) - 1);
 			}
 		} else
 			strcpy(data->s_mask, fieldptr->buf);
@@ -224,7 +225,8 @@ void gethostparams(struct hostparams *data, char *init_saddr, char *init_smask,
 				strcpy(data->d_mask, WILDCARD);
 			} else {
 				strncpy(data->d_mask,
-					cidr_get_quad_mask(maskbits), 20);
+					cidr_get_quad_mask(maskbits),
+					sizeof(data->d_mask) - 1);
 			}
 		} else
 			strcpy(data->d_mask, fieldptr->buf);

--- a/src/ipfilter.c
+++ b/src/ipfilter.c
@@ -52,7 +52,6 @@ void gethostparams(struct hostparams *data, char *init_saddr, char *init_smask,
 	int doagain;
 	unsigned int i;
 	char msgstr[60];
-	char actual_address[30];
 	unsigned int maskbits;
 
 	const char *WILDCARD = "0.0.0.0";
@@ -171,9 +170,7 @@ void gethostparams(struct hostparams *data, char *init_saddr, char *init_smask,
 			strcpy(data->s_fqdn, fieldptr->buf);
 
 		if (strchr(data->s_fqdn, '/') != NULL) {
-			cidr_split_address(data->s_fqdn, actual_address,
-					   &maskbits);
-			strcpy(data->s_fqdn, actual_address);
+			cidr_split_address(data->s_fqdn, &maskbits);
 		}
 
 		/*
@@ -211,9 +208,7 @@ void gethostparams(struct hostparams *data, char *init_saddr, char *init_smask,
 
 		maskbits = 0;
 		if (strchr(data->d_fqdn, '/') != NULL) {
-			cidr_split_address(data->d_fqdn, actual_address,
-					   &maskbits);
-			strcpy(data->d_fqdn, actual_address);
+			cidr_split_address(data->d_fqdn, &maskbits);
 		}
 
 		/*

--- a/src/iptraf-ng-compat.h
+++ b/src/iptraf-ng-compat.h
@@ -26,6 +26,7 @@
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <sys/un.h>
+#include <sys/mman.h>
 
 #include <netinet/in.h>
 #include <netinet/udp.h>

--- a/src/iptraf-ng-compat.h
+++ b/src/iptraf-ng-compat.h
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <poll.h>
 #include <limits.h>
+#include <locale.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/iptraf.c
+++ b/src/iptraf.c
@@ -456,6 +456,7 @@ int main(int argc, char **argv)
 	sanitize_dir(LOCKDIR);
 	sanitize_dir(WORKDIR);
 
+	setlocale(LC_ALL, "");	/* needed to properly init (n)curses library */
 	initscr();
 
 	if ((LINES < 24) || (COLS < 80)) {

--- a/src/iptraf.c
+++ b/src/iptraf.c
@@ -67,7 +67,7 @@ static void clearfiles(char *prefix, char *directory)
 {
 	DIR *dir;
 	struct dirent *dir_entry;
-	char target_name[80];
+	char target_name[PATH_MAX];
 
 	dir = opendir(directory);
 
@@ -83,8 +83,9 @@ static void clearfiles(char *prefix, char *directory)
 		if (dir_entry != NULL) {
 			if (strncmp(dir_entry->d_name, prefix, strlen(prefix))
 			    == 0) {
-				snprintf(target_name, 80, "%s/%s", directory,
-					 dir_entry->d_name);
+				snprintf(target_name, sizeof(target_name) - 1,
+					 "%s/%s", directory, dir_entry->d_name);
+				target_name[sizeof(target_name) - 1] = '\0';
 				unlink(target_name);
 			}
 		}

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -999,7 +999,6 @@ void ipmon(time_t facilitytime, char *ifptr)
 			last_time = now;
 		}
 
-		capt_put_packet(&capt, &pkt);
 		if (capt_get_packet(&capt, &pkt, &ch, table.tcpscreen) == -1) {
 			write_error("Packet receive failed");
 			exitloop = 1;
@@ -1014,6 +1013,7 @@ void ipmon(time_t facilitytime, char *ifptr)
 			ipmon_process_packet(&pkt, ifptr, &table, &othptbl,
 					     logging, logfile,
 					     &revlook, rvnfd);
+			capt_put_packet(&capt, &pkt);
 		}
 	}
 	packet_destroy(&pkt);

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -824,7 +824,8 @@ static void ipmon_process_packet(struct pkt_hdr *pkt, char *ifname,
 	case IPPROTO_ICMP:
 	case IPPROTO_ICMPV6:
 		check_icmp_dest_unreachable(table, pkt, ifname);
-		/* print this ICMP(v6): fall through */
+		/* print this ICMP(v6) and ... */
+		/* fall through */
 	default:
 		add_othp_entry(othptbl, pkt, &saddr, &daddr,
 			       IS_IP, pkt_ip_protocol(pkt),

--- a/src/othptab.c
+++ b/src/othptab.c
@@ -237,6 +237,8 @@ struct othptabent *add_othp_entry(struct othptable *table, struct pkt_hdr *pkt,
 					 IPPROTO_UDP, new_entry->un.udp.d_sname,
 					 10);
 			} else if (protocol == IPPROTO_OSPFIGP) {
+				new_entry->un.ospf.version =
+				    ((struct ospfhdr *) packet2)->ospf_version;
 				new_entry->un.ospf.type =
 				    ((struct ospfhdr *) packet2)->ospf_type;
 				new_entry->un.ospf.area =
@@ -677,6 +679,14 @@ void printothpentry(struct othptable *table, struct othptabent *entry,
 				break;
 			}
 		} else if (entry->protocol == IPPROTO_OSPFIGP) {
+			switch (entry->un.ospf.version) {
+			case 2:
+				strcat(protname, "v2");
+				break;
+			case 3:
+				strcat(protname, "v3");
+				break;
+			}
 			switch (entry->un.ospf.type) {
 			case OSPF_TYPE_HELLO:
 				strcpy(description, "hlo");

--- a/src/othptab.c
+++ b/src/othptab.c
@@ -360,7 +360,7 @@ void printothpentry(struct othptable *table, struct othptabent *entry,
 	char description[SHORTSTRING_MAX];
 	char additional[MSGSTRING_MAX];
 	char msgstring[MSGSTRING_MAX];
-	char scratchpad[MSGSTRING_MAX];
+	char scratchpad[2 * MSGSTRING_MAX];
 	char *startstr;
 
 	char *packet_type;

--- a/src/othptab.h
+++ b/src/othptab.h
@@ -43,6 +43,7 @@ struct othptabent {
 			unsigned int code;
 		} icmp;
 		struct {
+			unsigned char version;
 			unsigned char type;
 			unsigned long area;
 			char routerid[16];

--- a/src/packet.h
+++ b/src/packet.h
@@ -7,13 +7,6 @@ packet.h - external declarations for packet.c
 
 ***/
 
-/*
- * Number of bytes from captured packet to move into a buffer.
- * 96 bytes should be enough for the IP header, TCP/UDP/ICMP/whatever header
- * with reasonable numbers of options.
- */
-#define MAX_PACKET_SIZE 96
-
 #define INVALID_PACKET 0
 #define PACKET_OK 1
 #define CHECKSUM_ERROR 2
@@ -22,18 +15,16 @@ packet.h - external declarations for packet.c
 
 struct pkt_hdr {
 	char	       *pkt_buf;
-	size_t		pkt_bufsize;
 	char	       *pkt_payload;
 	size_t		pkt_caplen;	/* bytes captured */
 	size_t		pkt_len;	/* bytes on-the-wire */
 	unsigned short	pkt_protocol;	/* Physical layer protocol: ETH_P_* */
 
-	struct iovec	iov;
 	struct sockaddr_ll *from;
-	struct msghdr  *msg;
 
 	struct ethhdr  *ethhdr;
 	struct fddihdr *fddihdr;
+
 	struct iphdr   *iphdr;
 	struct ip6_hdr *ip6_hdr;
 };
@@ -61,13 +52,11 @@ static inline __u8 pkt_ip_protocol(const struct pkt_hdr *p)
 	return 0;
 }
 
-int packet_get(int fd, struct pkt_hdr *pkt, int *ch, WINDOW *win);
 int packet_process(struct pkt_hdr *pkt, unsigned int *total_br,
 		   in_port_t *sport, in_port_t *dport,
 		   int match_opposite, int v6inv4asv6);
 int packet_init(struct pkt_hdr *pkt);
 void packet_destroy(struct pkt_hdr *pkt);
-unsigned int packet_get_dropped(int fd);
 int packet_is_first_fragment(struct pkt_hdr *pkt);
 
 #endif	/* IPTRAF_NG_PACKET_H */

--- a/src/parseproto.c
+++ b/src/parseproto.c
@@ -44,31 +44,31 @@ void get_next_protorange(char **cptr, unsigned int *proto1,
 			 unsigned int *proto2, int *parse_result,
 			 char **badtokenptr)
 {
-	char toktmp[5];
-	char prototmp1[5];
-	char prototmp2[5];
+	char toktmp[6];
+	char prototmp1[6];
+	char prototmp2[6];
 	char *cerr_ptr;
-	static char bad_token[5];
+	static char bad_token[6];
 	unsigned int tmp;
 
-	memset(toktmp, 0, 5);
-	memset(prototmp1, 0, 5);
-	memset(prototmp2, 0, 5);
-	memset(bad_token, 0, 5);
+	memset(toktmp, 0, sizeof(toktmp));
+	memset(prototmp1, 0, sizeof(prototmp1));
+	memset(prototmp2, 0, sizeof(prototmp2));
+	memset(bad_token, 0, sizeof(bad_token));
 
-	strncpy(prototmp1, get_next_token(cptr), 5);
+	strncpy(prototmp1, get_next_token(cptr), sizeof(prototmp1) - 1);
 	if (prototmp1[0] == '\0') {
 		*parse_result = NO_MORE_TOKENS;
 		return;
 	}
 
-	strncpy(toktmp, get_next_token(cptr), 5);
+	strncpy(toktmp, get_next_token(cptr), sizeof(toktmp) - 1);
 
 	*parse_result = RANGE_OK;
 
 	switch (toktmp[0]) {
 	case '-':
-		strncpy(prototmp2, get_next_token(cptr), 5);
+		strncpy(prototmp2, get_next_token(cptr), sizeof(prototmp2) - 1);
 
 		/*
 		 * Check for missing right-hand token for -
@@ -85,7 +85,7 @@ void get_next_protorange(char **cptr, unsigned int *proto1,
 		 */
 		if (*cerr_ptr != '\0') {
 			*parse_result = INVALID_RANGE;
-			strncpy(bad_token, prototmp2, 5);
+			strncpy(bad_token, prototmp2, sizeof(bad_token));
 			*badtokenptr = bad_token;
 		} else {
 			/*
@@ -93,7 +93,7 @@ void get_next_protorange(char **cptr, unsigned int *proto1,
 			 */
 
 			if (*proto2 > 255) {
-				strncpy(bad_token, prototmp2, 5);
+				strncpy(bad_token, prototmp2, sizeof(bad_token));
 				*badtokenptr = bad_token;
 				*parse_result = OUT_OF_RANGE;
 			}
@@ -101,10 +101,10 @@ void get_next_protorange(char **cptr, unsigned int *proto1,
 			/*
 			 * Then check if the next token is a comma
 			 */
-			strncpy(toktmp, get_next_token(cptr), 5);
+			strncpy(toktmp, get_next_token(cptr), sizeof(toktmp) - 1);
 			if (toktmp[0] != '\0' && toktmp[0] != ',') {
 				*parse_result = COMMA_EXPECTED;
-				strncpy(bad_token, toktmp, 5);
+				strncpy(bad_token, toktmp, sizeof(bad_token));
 				*badtokenptr = bad_token;
 			}
 		}
@@ -116,7 +116,7 @@ void get_next_protorange(char **cptr, unsigned int *proto1,
 		break;
 	default:
 		*parse_result = COMMA_EXPECTED;
-		strncpy(bad_token, toktmp, 5);
+		strncpy(bad_token, toktmp, sizeof(bad_token));
 		*badtokenptr = bad_token;
 		break;
 	}
@@ -127,11 +127,11 @@ void get_next_protorange(char **cptr, unsigned int *proto1,
 	*proto1 = (unsigned int) strtoul(prototmp1, &cerr_ptr, 10);
 	if (*cerr_ptr != '\0') {
 		*parse_result = INVALID_RANGE;
-		strncpy(bad_token, prototmp1, 5);
+		strncpy(bad_token, prototmp1, sizeof(bad_token));
 		*badtokenptr = bad_token;
 	} else if (*proto1 > 255) {
 		*parse_result = OUT_OF_RANGE;
-		strncpy(bad_token, prototmp1, 5);
+		strncpy(bad_token, prototmp1, sizeof(bad_token));
 		*badtokenptr = bad_token;
 	} else
 		*badtokenptr = NULL;

--- a/src/revname.c
+++ b/src/revname.c
@@ -43,7 +43,10 @@ int rvnamedactive(void)
 	int br;
 	char unix_socket[80];
 
-	strncpy(unix_socket, get_path(T_WORKDIR, gen_unix_sockname()), 80);
+	strncpy(unix_socket,
+		get_path(T_WORKDIR, gen_unix_sockname()),
+		sizeof(unix_socket) - 1);
+	unix_socket[sizeof(unix_socket) - 1] = '\0';
 	unlink(unix_socket);
 
 	fd = socket(PF_UNIX, SOCK_DGRAM, 0);
@@ -116,7 +119,10 @@ void open_rvn_socket(int *fd)
 {
 	struct sockaddr_un su;
 
-	strncpy(revname_socket, get_path(T_WORKDIR, gen_unix_sockname()), 80);
+	strncpy(revname_socket,
+		get_path(T_WORKDIR, gen_unix_sockname()),
+		sizeof(revname_socket) - 1);
+	revname_socket[sizeof(revname_socket) - 1] = '\0';
 	unlink(revname_socket);
 
 	*fd = socket(PF_UNIX, SOCK_DGRAM, 0);

--- a/src/rvnamed.c
+++ b/src/rvnamed.c
@@ -295,7 +295,8 @@ int main(void)
 
 					sockaddr_copy(&hostlist[hi].addr, &rvnpacket.addr);
 				}
-				strncpy(hostlist[hi].fqdn, rvnpacket.fqdn, sizeof(hostlist[hi].fqdn) - 1);
+				strncpy(hostlist[hi].fqdn, rvnpacket.fqdn, sizeof(hostlist[hi].fqdn));
+				hostlist[hi].fqdn[sizeof(hostlist[hi].fqdn) - 1] = '\0';
 
 				hostlist[hi].ready = RESOLVED;
 			}

--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -458,7 +458,7 @@ static char *tcplog_flowrate_msg(struct tcptableent *entry, char *buf,
 	if (interval < 1)
 		interval = 1;
 
-	char rbuf[64];
+	char rbuf[32];
 	rate_print(entry->bcount / interval, rbuf, sizeof(rbuf));
 
 	snprintf(buf, bufsize - 1, "avg flow rate %s", rbuf);

--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -516,7 +516,7 @@ struct tcptableent *in_table(struct tcptable *table,
 	unsigned int hp;
 
 	if (table->head == NULL) {
-		return 0;
+		return NULL;
 	}
 	/*
 	 * Determine hash table index for this set of addresses and ports

--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -54,7 +54,7 @@ static unsigned int tcp_hash(struct sockaddr_storage *saddr,
 	size_t i;
 	unsigned int ifsum = 0;
 
-	for (i = 0; i <= strlen(ifname) - 1; i++)
+	for (i = 0; i < strlen(ifname); i++)
 		ifsum += ifname[i];
 
 	switch (saddr->ss_family) {

--- a/src/timer.c
+++ b/src/timer.c
@@ -17,5 +17,5 @@ void printelapsedtime(time_t elapsed, int x, WINDOW *win)
 
 	int y = getmaxy(win) - 1;
 
-	mvwprintw(win, y, x, " Elapsed time: %3u:%02u ", hours, mins);
+	mvwprintw(win, y, x, " Time: %3u:%02u ", hours, mins);
 }

--- a/src/tui/listbox.c
+++ b/src/tui/listbox.c
@@ -52,7 +52,7 @@ void tx_add_list_entry(struct scroll_list *list, char *node, char *text)
 
 	ptmp = xmallocz(sizeof(struct textlisttype));
 
-	strncpy(ptmp->text, text, MAX_TEXT_LENGTH);
+	strncpy(ptmp->text, text, MAX_TEXT_LENGTH - 1);
 	ptmp->nodeptr = node;
 
 	if (list->textlist == NULL) {

--- a/src/tui/listbox.c
+++ b/src/tui/listbox.c
@@ -176,6 +176,7 @@ void tx_operate_listbox(struct scroll_list *list, int *aborted)
 		case 24:
 			*aborted = 1;
 			endloop = 1;
+			/* fall through */
 		case 12:
 		case 'l':
 		case 'L':


### PR DESCRIPTION
accumulated changes over the years:
- packet capturing abstraction: this allow us to add various packet capturing interfaces
- add recvmmsg() packet capturing interface
- add mmaped TPACKET_V2 packet capturing interface
- show packet drop count
- code cleanups
- remove warnings from new compilers
- fix buffer overflow in cidr_split_address()
- fix bug: packets from not-selected interfaces got through even when we are properly bound to the correct interface
- add mmaped TPACKET_V3 packet capturing interface (the fastest option, least CPU usage)
- fix bug: don't hog the CPU when the selected interface disappears
- decrease CPU usage by polling for keypress only every 20ms (we used to poll for it every packet received!)