### PR TITLE
capt_recvmmsg_find_filled_slot(): fix the search to cover all the slots

### DIFF
--- a/src/capt-recvmmsg.c
+++ b/src/capt-recvmmsg.c
@@ -21,10 +21,12 @@ struct capt_data_recvmmsg {
 
 static unsigned int capt_recvmmsg_find_filled_slot(struct capt_data_recvmmsg *data)
 {
-	for (unsigned int slot = data->lastslot; slot < FRAMES; slot++)
+	for (unsigned int i = data->lastslot; i < data->lastslot + FRAMES; i++) {
+		unsigned int slot = i >= FRAMES ? i - FRAMES : i;
+
 		if (data->msgvec[slot].msg_len != 0)
 			return slot;
-
+	}
 	return FRAMES;
 }
 


### PR DESCRIPTION
This fixes the optimization: search the filled slot from the last found
slot not to the end of slot space but all of the slot space.

Fixes: eac07827db73f ("capt.c: add capturing using recvmmsg()")

Signed-off-by: Vitezslav Samel <vitezslav@samel.cz>