### PR TITLE
improve/simplify promisc handling

### DIFF
--- a/src/capt.c
+++ b/src/capt.c
@@ -98,8 +98,7 @@ out:
 
 void capt_destroy(struct capt *capt)
 {
-	promisc_restore_list(capt->fd, &capt->promisc);
-	promisc_destroy(&capt->promisc);
+	promisc_disable(capt->fd, &capt->promisc);
 
 	if (capt->cleanup)
 		capt->cleanup(capt);

--- a/src/capt.c
+++ b/src/capt.c
@@ -79,7 +79,7 @@ int capt_init(struct capt *capt, char *ifname)
 
 	if (options.promisc) {
 		promisc_init(&capt->promisc, ifname);
-		promisc_set_list(&capt->promisc);
+		promisc_set_list(capt->fd, &capt->promisc);
 	}
 
 	/* bind interface (and protocol) to socket
@@ -98,7 +98,7 @@ out:
 
 void capt_destroy(struct capt *capt)
 {
-	promisc_restore_list(&capt->promisc);
+	promisc_restore_list(capt->fd, &capt->promisc);
 	promisc_destroy(&capt->promisc);
 
 	if (capt->cleanup)

--- a/src/capt.c
+++ b/src/capt.c
@@ -88,8 +88,7 @@ int capt_init(struct capt *capt, char *ifname)
 	return 0;	/* all O.K. */
 
 out:
-	close(capt->fd);
-	capt->fd = -1;
+	capt_destroy(capt);
 
 	return -1;
 }

--- a/src/capt.c
+++ b/src/capt.c
@@ -77,10 +77,8 @@ int capt_init(struct capt *capt, char *ifname)
 	if (capt_setup_receive_function(capt) == -1)
 		goto out;
 
-	if (options.promisc) {
-		promisc_init(&capt->promisc, ifname);
-		promisc_set_list(capt->fd, &capt->promisc);
-	}
+	if (options.promisc)
+		promisc_enable(capt->fd, &capt->promisc, ifname);
 
 	/* bind interface (and protocol) to socket
 	 * (interface can be NULL -> any interface) */

--- a/src/capt.h
+++ b/src/capt.h
@@ -10,9 +10,13 @@
  */
 #define MAX_PACKET_SIZE 96
 
+#include "list.h"
+
 struct capt {
 	int		fd;
 	unsigned long	dropped;
+
+	struct list_head promisc;
 
 	void		*priv;
 

--- a/src/detstats.c
+++ b/src/detstats.c
@@ -23,7 +23,6 @@ detstats.c	- the interface statistics module
 #include "serv.h"
 #include "timer.h"
 #include "logvars.h"
-#include "promisc.h"
 #include "error.h"
 #include "detstats.h"
 #include "rate.h"
@@ -544,12 +543,6 @@ void detstats(char *iface, time_t facilitytime)
 	update_panels();
 	doupdate();
 
-	LIST_HEAD(promisc);
-	if (options.promisc) {
-		promisc_init(&promisc, iface);
-		promisc_set_list(&promisc);
-	}
-
 	if (capt_init(&capt, iface) == -1) {
 		write_error("Unable to initialize packet capture interface");
 		goto err;
@@ -671,11 +664,6 @@ void detstats(char *iface, time_t facilitytime)
 	ifcounts_destroy(&ifcounts);
 	capt_destroy(&capt);
 err:
-	if (options.promisc) {
-		promisc_restore_list(&promisc);
-		promisc_destroy(&promisc);
-	}
-
 	del_panel(statpanel);
 	delwin(statwin);
 	update_panels();

--- a/src/hostmon.c
+++ b/src/hostmon.c
@@ -25,7 +25,6 @@ Discovers LAN hosts and displays packet statistics for them
 #include "landesc.h"
 #include "options.h"
 #include "logvars.h"
-#include "promisc.h"
 #include "error.h"
 #include "rate.h"
 #include "capt.h"
@@ -917,12 +916,6 @@ void hostmon(time_t facilitytime, char *ifptr)
 
 	initethtab(&table);
 
-	LIST_HEAD(promisc);
-	if (options.promisc) {
-		promisc_init(&promisc, ifptr);
-		promisc_set_list(&promisc);
-	}
-
 	if (capt_init(&capt, ifptr) == -1) {
 		write_error("Unable to initialize packet capture interface");
 		goto err;
@@ -1031,10 +1024,5 @@ void hostmon(time_t facilitytime, char *ifptr)
 
 	capt_destroy(&capt);
 err:
-	if (options.promisc) {
-		promisc_restore_list(&promisc);
-		promisc_destroy(&promisc);
-	}
-
 	destroyethtab(&table);
 }

--- a/src/ifaces.c
+++ b/src/ifaces.c
@@ -265,18 +265,3 @@ int dev_bind_ifname(int fd, const char * const ifname)
 
 	return dev_bind_ifindex(fd, ifindex);
 }
-
-int dev_promisc_flag(const char *dev_name)
-{
-	int flags = dev_get_flags(dev_name);
-	if (flags < 0) {
-		write_error("Unable to obtain interface parameters for %s",
-			    dev_name);
-		return -1;
-	}
-
-	if (flags & IFF_PROMISC)
-		return -1;
-
-	return flags;
-}

--- a/src/ifaces.h
+++ b/src/ifaces.h
@@ -1,9 +1,6 @@
 #ifndef IPTRAF_NG_IFACES_H
 #define IPTRAF_NG_IFACES_H
 
-#define dev_set_promisc(dev)   dev_set_flags((dev), IFF_PROMISC)
-#define dev_clr_promisc(dev)   dev_clear_flags((dev), IFF_PROMISC)
-
 FILE *open_procnetdev(void);
 int get_next_iface(FILE * fd, char *ifname, int n);
 int dev_up(char *iface);
@@ -15,6 +12,5 @@ int dev_set_flags(const char *iface, int flags);
 int dev_clear_flags(const char *iface, int flags);
 int dev_get_ifname(int ifindex, char *ifname);
 int dev_bind_ifname(const int fd, const char * const ifname);
-int dev_promisc_flag(const char *dev_name);
 
 #endif	/* IPTRAF_NG_IFACES_H */

--- a/src/ifstats.c
+++ b/src/ifstats.c
@@ -25,7 +25,6 @@ ifstats.c	- the interface statistics module
 #include "serv.h"
 #include "timer.h"
 #include "logvars.h"
-#include "promisc.h"
 #include "error.h"
 #include "ifstats.h"
 #include "rate.h"
@@ -535,12 +534,6 @@ void ifstats(time_t facilitytime)
 
 	initiftab(&table);
 
-	LIST_HEAD(promisc);
-	if (options.promisc) {
-		promisc_init(&promisc, NULL);
-		promisc_set_list(&promisc);
-	}
-
 	if (capt_init(&capt, NULL) == -1) {
 		write_error("Unable to initialize packet capture interface");
 		goto err;
@@ -662,11 +655,6 @@ void ifstats(time_t facilitytime)
 
 	capt_destroy(&capt);
 err:
-	if (options.promisc) {
-		promisc_restore_list(&promisc);
-		promisc_destroy(&promisc);
-	}
-
 	del_panel(table.statpanel);
 	delwin(table.statwin);
 	del_panel(table.borderpanel);

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -18,7 +18,6 @@ itrafmon.c - the IP traffic monitor module
 #include "fltdefs.h"
 #include "packet.h"
 #include "ifaces.h"
-#include "promisc.h"
 #include "deskman.h"
 #include "error.h"
 #include "attrs.h"
@@ -865,15 +864,9 @@ void ipmon(time_t facilitytime, char *ifptr)
 		return;
 	}
 
-	LIST_HEAD(promisc);
-	if (options.promisc) {
-		promisc_init(&promisc, ifptr);
-		promisc_set_list(&promisc);
-	}
-
 	if (capt_init(&capt, ifptr) == -1) {
 		write_error("Unable to initialize packet capture interface");
-		goto err;
+		return;
 	}
 
 	if (revlook) {
@@ -1039,9 +1032,4 @@ void ipmon(time_t facilitytime, char *ifptr)
 	close_rvn_socket(rvnfd);
 
 	capt_destroy(&capt);
-err:
-	if (options.promisc) {
-		promisc_restore_list(&promisc);
-		promisc_destroy(&promisc);
-	}
 }

--- a/src/options.c
+++ b/src/options.c
@@ -19,7 +19,6 @@ options.c - implements the configuration section of the utility
 #include "deskman.h"
 #include "attrs.h"
 #include "landesc.h"
-#include "promisc.h"
 #include "dirs.h"
 
 #define ALLOW_ZERO 1

--- a/src/pktsize.c
+++ b/src/pktsize.c
@@ -23,7 +23,6 @@ pktsize.c	- the packet size breakdown facility
 #include "timer.h"
 #include "log.h"
 #include "logvars.h"
-#include "promisc.h"
 #include "capt.h"
 
 #define SIZES 20
@@ -244,12 +243,6 @@ void packet_size_breakdown(char *ifname, time_t facilitytime)
 
 	psizetab_init(&table, ifname);
 
-	LIST_HEAD(promisc);
-	if (options.promisc) {
-		promisc_init(&promisc, ifname);
-		promisc_set_list(&promisc);
-	}
-
 	if (capt_init(&capt, ifname) == -1) {
 		write_error("Unable to initialize packet capture interface");
 		goto err;
@@ -368,10 +361,5 @@ void packet_size_breakdown(char *ifname, time_t facilitytime)
 err_close:
 	capt_destroy(&capt);
 err:
-	if (options.promisc) {
-		promisc_restore_list(&promisc);
-		promisc_destroy(&promisc);
-	}
-
 	psizetab_destroy(&table);
 }

--- a/src/promisc.c
+++ b/src/promisc.c
@@ -14,6 +14,11 @@ promisc.c	- handles the promiscuous mode flag for the Ethernet/FDDI/
 #include "error.h"
 #include "promisc.h"
 
+struct promisc_list {
+	struct list_head list;
+	char ifname[IFNAMSIZ];
+};
+
 static void promisc_add_dev(struct list_head *promisc, const char *dev_name)
 {
 	struct promisc_list *p = xmallocz(sizeof(*p));

--- a/src/promisc.c
+++ b/src/promisc.c
@@ -98,20 +98,14 @@ void promisc_set_list(int sock, struct list_head *promisc)
 	}
 }
 
-void promisc_restore_list(int sock, struct list_head *promisc)
-{
-	struct promisc_list *entry = NULL;
-	list_for_each_entry(entry, promisc, list) {
-		int r = sock_disable_promisc(sock, entry->ifindex);
-		if (r < 0)
-			write_error("Failed to clear promiscuous mode on %s", entry->ifname);
-	}
-}
-
-void promisc_destroy(struct list_head *promisc)
+void promisc_disable(int sock, struct list_head *promisc)
 {
 	struct promisc_list *entry, *tmp;
 	list_for_each_entry_safe(entry, tmp, promisc, list) {
+		int r = sock_disable_promisc(sock, entry->ifindex);
+		if (r < 0)
+			write_error("Failed to clear promiscuous mode on %s", entry->ifname);
+
 		list_del(&entry->list);
 		free(entry);
 	}

--- a/src/promisc.h
+++ b/src/promisc.h
@@ -6,7 +6,7 @@
 void promisc_init(struct list_head *promisc, const char *device_name);
 void promisc_destroy(struct list_head *promisc);
 
-void promisc_set_list(struct list_head *promisc);
-void promisc_restore_list(struct list_head *promisc);
+void promisc_set_list(int sock, struct list_head *promisc);
+void promisc_restore_list(int sock, struct list_head *promisc);
 
 #endif	/* IPTRAF_NG_PROMISC_H */

--- a/src/promisc.h
+++ b/src/promisc.h
@@ -4,9 +4,8 @@
 #include "list.h"
 
 void promisc_init(struct list_head *promisc, const char *device_name);
-void promisc_destroy(struct list_head *promisc);
 
 void promisc_set_list(int sock, struct list_head *promisc);
-void promisc_restore_list(int sock, struct list_head *promisc);
+void promisc_disable(int sock, struct list_head *promisc);
 
 #endif	/* IPTRAF_NG_PROMISC_H */

--- a/src/promisc.h
+++ b/src/promisc.h
@@ -3,11 +3,6 @@
 
 #include "list.h"
 
-struct promisc_list {
-	struct list_head list;
-	char ifname[IFNAMSIZ];
-};
-
 void promisc_init(struct list_head *promisc, const char *device_name);
 void promisc_destroy(struct list_head *promisc);
 

--- a/src/promisc.h
+++ b/src/promisc.h
@@ -3,9 +3,7 @@
 
 #include "list.h"
 
-void promisc_init(struct list_head *promisc, const char *device_name);
-
-void promisc_set_list(int sock, struct list_head *promisc);
+void promisc_enable(int sock, struct list_head *promisc, const char *device_name);
 void promisc_disable(int sock, struct list_head *promisc);
 
 #endif	/* IPTRAF_NG_PROMISC_H */

--- a/src/serv.c
+++ b/src/serv.c
@@ -25,7 +25,6 @@ serv.c  - TCP/UDP port statistics module
 #include "servname.h"
 #include "log.h"
 #include "timer.h"
-#include "promisc.h"
 #include "options.h"
 #include "packet.h"
 #include "logvars.h"
@@ -914,12 +913,6 @@ void servmon(char *ifname, time_t facilitytime)
 	initportlist(&list);
 	loadaddports(&ports);
 
-	LIST_HEAD(promisc);
-	if (options.promisc) {
-		promisc_init(&promisc, ifname);
-		promisc_set_list(&promisc);
-	}
-
 	if (capt_init(&capt, ifname) == -1) {
 		write_error("Unable to initialize packet capture interface");
 		goto err;
@@ -1035,11 +1028,6 @@ void servmon(char *ifname, time_t facilitytime)
 
 	capt_destroy(&capt);
 err:
-	if (options.promisc) {
-		promisc_restore_list(&promisc);
-		promisc_destroy(&promisc);
-	}
-
 	destroyporttab(ports);
 	destroyportlist(&list);
 }


### PR DESCRIPTION
This series cleans up and improves promiscuous mode handling:
- enables it only on running interfaces
- hides it by move to capt_* abstraction
- changes it to the recommended way of enabling