### PR TITLE
various fixes, cleanups and optimizations

### DIFF
--- a/src/capt-mmap-v2.c
+++ b/src/capt-mmap-v2.c
@@ -29,11 +29,14 @@ static unsigned int capt_mmap_find_filled_slot(struct capt_data_mmap_v2 *data)
 	return FRAMES;
 }
 
-static unsigned int capt_have_packet_mmap_v2(struct capt *capt)
+static bool capt_have_packet_mmap_v2(struct capt *capt)
 {
 	struct capt_data_mmap_v2 *data = capt->priv;
 
-	return capt_mmap_find_filled_slot(data) != FRAMES;
+	if (capt_mmap_find_filled_slot(data) != FRAMES)
+		return true;
+	else
+		return false;
 }
 
 static int capt_get_packet_mmap_v2(struct capt *capt, struct pkt_hdr *pkt)

--- a/src/capt-mmap-v3.c
+++ b/src/capt-mmap-v3.c
@@ -44,7 +44,7 @@ static struct tpacket_block_desc *capt_mmap_find_filled_block(struct capt_data_m
 	return NULL;
 }
 
-static unsigned int capt_have_packet_mmap_v3(struct capt *capt)
+static bool capt_have_packet_mmap_v3(struct capt *capt)
 {
 	struct capt_data_mmap_v3 *data = capt->priv;
 

--- a/src/capt-recvmmsg.c
+++ b/src/capt-recvmmsg.c
@@ -30,11 +30,14 @@ static unsigned int capt_recvmmsg_find_filled_slot(struct capt_data_recvmmsg *da
 	return FRAMES;
 }
 
-static unsigned int capt_have_packet_recvmmsg(struct capt *capt)
+static bool capt_have_packet_recvmmsg(struct capt *capt)
 {
 	struct capt_data_recvmmsg *data = capt->priv;
 
-	return capt_recvmmsg_find_filled_slot(data) != FRAMES;
+	if (capt_recvmmsg_find_filled_slot(data) != FRAMES)
+		return true;
+	else
+		return false;
 }
 
 static int capt_get_packet_recvmmsg(struct capt *capt, struct pkt_hdr *pkt)

--- a/src/capt-recvmsg.c
+++ b/src/capt-recvmsg.c
@@ -14,9 +14,9 @@ struct capt_data_recvmsg {
 	struct sockaddr_ll	*from;
 };
 
-static unsigned int capt_have_packet_recvmsg(struct capt *capt __unused)
+static bool capt_have_packet_recvmsg(struct capt *capt __unused)
 {
-	return 0;
+	return false;
 }
 
 static int capt_get_packet_recvmsg(struct capt *capt, struct pkt_hdr *pkt)

--- a/src/capt.c
+++ b/src/capt.c
@@ -54,6 +54,7 @@ int capt_init(struct capt *capt, char *ifname)
 	capt->have_packet = NULL;
 	capt->get_packet = NULL;
 	capt->put_packet = NULL;
+	capt->get_dropped = NULL;
 	capt->cleanup = NULL;
 
 	capt->dropped = 0UL;
@@ -105,7 +106,7 @@ void capt_destroy(struct capt *capt)
 	capt->fd = -1;
 }
 
-unsigned long capt_get_dropped(struct capt *capt)
+static unsigned long capt_get_dropped_generic(struct capt *capt)
 {
 	struct tpacket_stats stats;
 	socklen_t len = sizeof(stats);
@@ -118,6 +119,14 @@ unsigned long capt_get_dropped(struct capt *capt)
 	capt->dropped += stats.tp_drops;
 
 	return capt->dropped;
+}
+
+unsigned long capt_get_dropped(struct capt *capt)
+{
+	if (capt->get_dropped)
+		return capt->get_dropped(capt);
+
+	return capt_get_dropped_generic(capt);
 }
 
 int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win)

--- a/src/capt.c
+++ b/src/capt.c
@@ -8,6 +8,7 @@
 #include "error.h"
 #include "ifaces.h"
 #include "packet.h"
+#include "timer.h"
 #include "capt.h"
 #include "capt-recvmsg.h"
 #include "capt-recvmmsg.h"
@@ -117,33 +118,6 @@ unsigned long capt_get_dropped(struct capt *capt)
 	capt->dropped += stats.tp_drops;
 
 	return capt->dropped;
-}
-
-static bool time_after(struct timespec const *a, struct timespec const *b)
-{
-	if (a->tv_sec > b->tv_sec)
-		return true;
-	if (a->tv_sec < b->tv_sec)
-		return false;
-	if(a->tv_nsec > b->tv_nsec)
-		return true;
-	else
-		return false;
-}
-
-static void time_add_msecs(struct timespec *time, unsigned int msecs)
-{
-	if (time != NULL) {
-		while (msecs >= 1000) {
-			time->tv_sec++;
-			msecs -= 1000;
-		}
-		time->tv_nsec += msecs * 1000000;
-		while (time->tv_nsec >= 1000000000) {
-			time->tv_sec++;
-			time->tv_nsec -= 1000000000;
-		}
-	}
 }
 
 int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win)

--- a/src/capt.c
+++ b/src/capt.c
@@ -119,29 +119,29 @@ unsigned long capt_get_dropped(struct capt *capt)
 	return capt->dropped;
 }
 
-static bool time_after(struct timeval const *a, struct timeval const *b)
+static bool time_after(struct timespec const *a, struct timespec const *b)
 {
 	if (a->tv_sec > b->tv_sec)
 		return true;
 	if (a->tv_sec < b->tv_sec)
 		return false;
-	if(a->tv_usec > b->tv_usec)
+	if(a->tv_nsec > b->tv_nsec)
 		return true;
 	else
 		return false;
 }
 
-static void time_add_msecs(struct timeval *time, unsigned int msecs)
+static void time_add_msecs(struct timespec *time, unsigned int msecs)
 {
 	if (time != NULL) {
 		while (msecs >= 1000) {
 			time->tv_sec++;
 			msecs -= 1000;
 		}
-		time->tv_usec += msecs * 1000;
-		while (time->tv_usec >= 1000000) {
+		time->tv_nsec += msecs * 1000000;
+		while (time->tv_nsec >= 1000000000) {
 			time->tv_sec++;
-			time->tv_usec -= 1000000;
+			time->tv_nsec -= 1000000000;
 		}
 	}
 }
@@ -155,7 +155,7 @@ int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win
 	int ss = 0;
 	int have_packet = capt->have_packet(capt);
 	int timeout = ch ? DEFAULT_UPDATE_DELAY : -1;
-	static struct timeval next_kbd_check = { 0 };
+	static struct timespec next_kbd_check = { 0 };
 
 	/* no packet ready, so poll() for it */
 	if (!have_packet) {
@@ -168,9 +168,9 @@ int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win
 	/* check for key press */
 	/* Monitor stdin only if in interactive, not daemon mode. */
 	if (ch && !daemonized) {
-		struct timeval now;
+		struct timespec now;
 
-		gettimeofday(&now, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 		if (time_after(&now, &next_kbd_check)) {
 			pfds[nfds].fd = 0;
 			pfds[nfds].events = POLLIN;

--- a/src/capt.c
+++ b/src/capt.c
@@ -136,7 +136,7 @@ int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win
 	int pfd_packet = -1;
 	int pfd_key = -1;
 	int ss = 0;
-	int have_packet = capt->have_packet(capt);
+	bool have_packet = capt->have_packet(capt);
 	int timeout = ch ? DEFAULT_UPDATE_DELAY : -1;
 	static struct timespec next_kbd_check = { 0 };
 

--- a/src/capt.h
+++ b/src/capt.h
@@ -20,7 +20,7 @@ struct capt {
 
 	void		*priv;
 
-	unsigned int	(*have_packet)(struct capt *capt);
+	bool		(*have_packet)(struct capt *capt);
 	int		(*get_packet)(struct capt *capt, struct pkt_hdr *pkt);
 	int		(*put_packet)(struct capt *capt, struct pkt_hdr *pkt);
 	unsigned long	(*get_dropped)(struct capt *capt);

--- a/src/capt.h
+++ b/src/capt.h
@@ -23,6 +23,7 @@ struct capt {
 	unsigned int	(*have_packet)(struct capt *capt);
 	int		(*get_packet)(struct capt *capt, struct pkt_hdr *pkt);
 	int		(*put_packet)(struct capt *capt, struct pkt_hdr *pkt);
+	unsigned long	(*get_dropped)(struct capt *capt);
 	void		(*cleanup)(struct capt *capt);
 };
 

--- a/src/deskman.c
+++ b/src/deskman.c
@@ -15,6 +15,7 @@ deskman.c - desktop management routines
 
 #include "deskman.h"
 #include "options.h"
+#include "timer.h"
 
 /* Attribute variables */
 
@@ -196,20 +197,19 @@ void print_packet_drops(unsigned long count, WINDOW *win, int x)
 	mvwprintw(win, getmaxy(win) - 1, x, " Drops: %9lu ", count);
 }
 
-int screen_update_needed(const struct timespec *now, const struct timespec *last)
+static unsigned int get_screen_update_rate(void)
 {
-	unsigned long msecs = timespec_diff_msec(now, last);
-	if (options.updrate == 0) {
-		if (msecs >= DEFAULT_UPDATE_DELAY)
-			return 1;
-		else
-			return 0;
-	} else {
-		if (msecs >= (options.updrate * 1000UL))
-			return 1;
-		else
-			return 0;
-	}
+	if (options.updrate == 0)
+		return DEFAULT_UPDATE_DELAY;
+	else
+		return options.updrate * 1000UL;
+}
+
+void set_next_screen_update(struct timespec *next_screen_update,
+			    struct timespec *now)
+{
+	*next_screen_update = *now;
+	time_add_msecs(next_screen_update, get_screen_update_rate());
 }
 
 void standardcolors(int color)

--- a/src/deskman.c
+++ b/src/deskman.c
@@ -196,9 +196,9 @@ void print_packet_drops(unsigned long count, WINDOW *win, int x)
 	mvwprintw(win, getmaxy(win) - 1, x, " Drops: %9lu ", count);
 }
 
-int screen_update_needed(const struct timeval *now, const struct timeval *last)
+int screen_update_needed(const struct timespec *now, const struct timespec *last)
 {
-	unsigned long msecs = timeval_diff_msec(now, last);
+	unsigned long msecs = timespec_diff_msec(now, last);
 	if (options.updrate == 0) {
 		if (msecs >= DEFAULT_UPDATE_DELAY)
 			return 1;

--- a/src/deskman.h
+++ b/src/deskman.h
@@ -18,7 +18,7 @@ void stdexitkeyhelp(void);
 void indicate(char *message);
 void printlargenum(unsigned long long i, WINDOW * win);
 void print_packet_drops(unsigned long count, WINDOW *win, int x);
-int screen_update_needed(const struct timeval *now, const struct timeval *last);
+int screen_update_needed(const struct timespec *now, const struct timespec *last);
 void infobox(char *text, char *prompt);
 void standardcolors(int color);
 void show_sort_statwin(WINDOW **, PANEL **);

--- a/src/deskman.h
+++ b/src/deskman.h
@@ -18,7 +18,7 @@ void stdexitkeyhelp(void);
 void indicate(char *message);
 void printlargenum(unsigned long long i, WINDOW * win);
 void print_packet_drops(unsigned long count, WINDOW *win, int x);
-int screen_update_needed(const struct timespec *now, const struct timespec *last);
+void set_next_screen_update(struct timespec *next_screen_update, struct timespec *now);
 void infobox(char *text, char *prompt);
 void standardcolors(int color);
 void show_sort_statwin(WINDOW **, PANEL **);

--- a/src/detstats.c
+++ b/src/detstats.c
@@ -584,10 +584,10 @@ void detstats(char *iface, time_t facilitytime)
 
 	exitloop = 0;
 
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timeval last_time = now;
-	struct timeval last_update = now;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	struct timespec last_time = now;
+	struct timespec last_update = now;
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -600,10 +600,10 @@ void detstats(char *iface, time_t facilitytime)
 
 	/* data-gathering loop */
 	while (!exitloop) {
-		gettimeofday(&now, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		if (now.tv_sec > last_time.tv_sec) {
-			unsigned long msecs = timeval_diff_msec(&now, &last_time);
+			unsigned long msecs = timespec_diff_msec(&now, &last_time);
 			ifrates_update(&ifrates, &ifcounts, msecs);
 			ifrates_show(&ifrates, statwin);
 

--- a/src/detstats.c
+++ b/src/detstats.c
@@ -587,7 +587,7 @@ void detstats(char *iface, time_t facilitytime)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	struct timespec last_time = now;
-	struct timespec last_update = now;
+	struct timespec next_screen_update = { 0 };
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -625,12 +625,12 @@ void detstats(char *iface, time_t facilitytime)
 
 			last_time = now;
 		}
-		if (screen_update_needed(&now, &last_update)) {
+		if (time_after(&now, &next_screen_update)) {
 			printdetails(&ifcounts, statwin);
 			update_panels();
 			doupdate();
 
-			last_update = now;
+			set_next_screen_update(&next_screen_update, &now);
 		}
 
 		if (capt_get_packet(&capt, &pkt, &ch, statwin) == -1) {

--- a/src/hostmon.c
+++ b/src/hostmon.c
@@ -434,18 +434,6 @@ static void print_entry_rates(struct ethtab *table, struct ethtabent *entry)
 	mvwprintw(table->tabwin, target_row, 69 * COLS / 80, "%s", buf);
 }
 
-static void print_visible_rates(struct ethtab *table)
-{
-	struct ethtabent *entry = table->firstvisible;
-
-	while ((entry != NULL) && (entry->prev_entry != table->lastvisible)) {
-		print_entry_rates(table, entry);
-		entry = entry->next_entry;
-	}
-	update_panels();
-	doupdate();
-}
-
 static void updateethrates(struct ethtab *table, unsigned long msecs)
 {
 	struct ethtabent *ptmp = table->head;
@@ -471,6 +459,8 @@ static void print_visible_entries(struct ethtab *table)
 
 	while ((ptmp != NULL) && (ptmp->prev_entry != table->lastvisible)) {
 		printethent(table, ptmp);
+		print_entry_rates(table, ptmp);
+
 		ptmp = ptmp->next_entry;
 	}
 }
@@ -481,7 +471,6 @@ static void refresh_hostmon_screen(struct ethtab *table)
 	tx_colorwin(table->tabwin);
 
 	print_visible_entries(table);
-	print_visible_rates(table);
 
 	update_panels();
 	doupdate();
@@ -949,7 +938,6 @@ void hostmon(time_t facilitytime, char *ifptr)
 		if (now.tv_sec > last_time.tv_sec) {
 			unsigned long msecs = timespec_diff_msec(&now, &last_time);
 			updateethrates(&table, msecs);
-			print_visible_rates(&table);
 
 			printelapsedtime(now.tv_sec - starttime, 15, table.borderwin);
 

--- a/src/hostmon.c
+++ b/src/hostmon.c
@@ -932,7 +932,7 @@ void hostmon(time_t facilitytime, char *ifptr)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	struct timespec last_time = now;
-	struct timespec last_update = now;
+	struct timespec next_screen_update = { 0 };
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -967,11 +967,12 @@ void hostmon(time_t facilitytime, char *ifptr)
 
 			last_time = now;
 		}
-		if (screen_update_needed(&now, &last_update)) {
+		if (time_after(&now, &next_screen_update)) {
 			print_visible_entries(&table);
 			update_panels();
 			doupdate();
-			last_update = now;
+
+			set_next_screen_update(&next_screen_update, &now);
 		}
 
 		if (capt_get_packet(&capt, &pkt, &ch, table.tabwin) == -1) {

--- a/src/hostmon.c
+++ b/src/hostmon.c
@@ -929,10 +929,10 @@ void hostmon(time_t facilitytime, char *ifptr)
 
 	exitloop = 0;
 
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timeval last_time = now;
-	struct timeval last_update = now;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	struct timespec last_time = now;
+	struct timespec last_update = now;
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -944,10 +944,10 @@ void hostmon(time_t facilitytime, char *ifptr)
 		log_next = now.tv_sec + options.logspan;
 
 	while (!exitloop) {
-		gettimeofday(&now, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		if (now.tv_sec > last_time.tv_sec) {
-			unsigned long msecs = timeval_diff_msec(&now, &last_time);
+			unsigned long msecs = timespec_diff_msec(&now, &last_time);
 			updateethrates(&table, msecs);
 			print_visible_rates(&table);
 

--- a/src/ifstats.c
+++ b/src/ifstats.c
@@ -573,10 +573,10 @@ void ifstats(time_t facilitytime)
 
 	exitloop = 0;
 
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timeval last_time = now;
-	struct timeval last_update = now;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	struct timespec last_time = now;
+	struct timespec last_update = now;
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -588,10 +588,10 @@ void ifstats(time_t facilitytime)
 		log_next = now.tv_sec + options.logspan;
 
 	while (!exitloop) {
-		gettimeofday(&now, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		if (now.tv_sec > last_time.tv_sec) {
-			unsigned long msecs = timeval_diff_msec(&now, &last_time);
+			unsigned long msecs = timespec_diff_msec(&now, &last_time);
 			updaterates(&table, msecs);
 			showrates(&table);
 

--- a/src/ifstats.c
+++ b/src/ifstats.c
@@ -576,7 +576,7 @@ void ifstats(time_t facilitytime)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	struct timespec last_time = now;
-	struct timespec last_update = now;
+	struct timespec next_screen_update = { 0 };
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -619,12 +619,12 @@ void ifstats(time_t facilitytime)
 
 			last_time = now;
 		}
-		if (screen_update_needed(&now, &last_update)) {
+		if (time_after(&now, &next_screen_update)) {
 			print_if_entries(&table);
 			update_panels();
 			doupdate();
 
-			last_update = now;
+			set_next_screen_update(&next_screen_update, &now);
 		}
 
 		if (capt_get_packet(&capt, &pkt, &ch, table.statwin) == -1) {

--- a/src/iptraf-ng-compat.h
+++ b/src/iptraf-ng-compat.h
@@ -73,9 +73,6 @@
 
 #define KBITS 0
 
-#define dispmode(mode)				\
-	(((mode) == KBITS) ? "kbps": "kBps")
-
 #define __noreturn	__attribute__((noreturn))
 #define __unused	__attribute__((unused))
 #define __printf(x, y)	__attribute__((format(printf, (x), (y))))

--- a/src/iptraf-ng-compat.h
+++ b/src/iptraf-ng-compat.h
@@ -128,21 +128,21 @@ static inline char *skip_whitespace(char *str)
 	return str;
 }
 
-static inline unsigned long timeval_diff_msec(const struct timeval *end,
-					      const struct timeval *start)
+static inline unsigned long timespec_diff_msec(const struct timespec *end,
+					       const struct timespec *start)
 {
 	if (!start || !end)
 		return 0UL;
 
 	signed long secs = end->tv_sec - start->tv_sec;
-	signed long usecs = end->tv_usec - start->tv_usec;
+	signed long nsecs = end->tv_nsec - start->tv_nsec;
 
-	if(usecs < 0) {
-		usecs = 1000000 - usecs;
+	if(nsecs < 0) {
+		nsecs = 1000000000UL - nsecs;
 		secs -= 1;
 	}
 	if(secs >= 0)
-		return secs * 1000UL + usecs / 1000UL;
+		return secs * 1000UL + nsecs / 1000000UL;
 	else
 		return 0UL;
 }

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -728,17 +728,11 @@ static void ipmon_process_packet(struct pkt_hdr *pkt, char *ifname,
 			 * Ok, so we have a packet.  Add it if this connection
 			 * is not yet closed, or if it is a SYN packet.
 			 */
-			int wasempty = (table->head == NULL);
 			tcpentry = addentry(table, &saddr, &daddr,
 					    pkt_ip_protocol(pkt),
 					    ifname, revlook, rvnfd);
-			if (tcpentry != NULL) {
+			if (tcpentry != NULL)
 				printentry(table, tcpentry->oth_connection);
-
-				if (wasempty) {
-					table->barptr = table->firstvisible;
-				}
-			}
 		}
 		/*
 		 * If we had an addentry() success, we should have no

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -910,6 +910,8 @@ void ipmon(time_t facilitytime, char *ifptr)
 			/* ... and print the current one every second */
 			print_flowrate(&table);
 
+			resolve_visible_entries(&table, &revlook, rvnfd);
+
 			/* print timer at bottom of screen */
 			printelapsedtime(now.tv_sec - starttime, 15, othptbl.borderwin);
 

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -924,10 +924,10 @@ void ipmon(time_t facilitytime, char *ifptr)
 
 	exitloop = 0;
 
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timeval last_time = now;
-	struct timeval updtime = now;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	struct timespec last_time = now;
+	struct timespec updtime = now;
 	time_t starttime = now.tv_sec;
 
 	time_t check_closed;
@@ -944,7 +944,7 @@ void ipmon(time_t facilitytime, char *ifptr)
 		endtime = INT_MAX;
 
 	while (!exitloop) {
-		gettimeofday(&now, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		/* update screen at configured intervals. */
 		if (screen_update_needed(&now, &updtime)) {
@@ -956,7 +956,7 @@ void ipmon(time_t facilitytime, char *ifptr)
 		}
 
 		if (now.tv_sec > last_time.tv_sec) {
-			unsigned long msecs = timeval_diff_msec(&now, &last_time);
+			unsigned long msecs = timespec_diff_msec(&now, &last_time);
 			/* update all flowrates ... */
 			update_flowrates(&table, msecs);
 			/* ... and print the current one every second */

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -927,7 +927,7 @@ void ipmon(time_t facilitytime, char *ifptr)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	struct timespec last_time = now;
-	struct timespec updtime = now;
+	struct timespec next_screen_update = { 0 };
 	time_t starttime = now.tv_sec;
 
 	time_t check_closed;
@@ -947,12 +947,12 @@ void ipmon(time_t facilitytime, char *ifptr)
 		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		/* update screen at configured intervals. */
-		if (screen_update_needed(&now, &updtime)) {
+		if (time_after(&now, &next_screen_update)) {
 			show_stats(table.statwin, total_pkts);
 			update_panels();
 			doupdate();
 
-			updtime = now;
+			set_next_screen_update(&next_screen_update, &now);
 		}
 
 		if (now.tv_sec > last_time.tv_sec) {

--- a/src/options.c
+++ b/src/options.c
@@ -57,7 +57,7 @@ static void makeoptionmenu(struct MENU *menu)
 	tx_additem(menu, NULL, NULL);
 	tx_additem(menu, " ^E^thernet/PLIP host descriptions...",
 		   "Manages descriptions for Ethernet and PLIP addresses");
-	tx_additem(menu, " ^F^DDI/Token Ring host descriptions...",
+	tx_additem(menu, " ^F^DDI host descriptions...",
 		   "Manages descriptions for FDDI and FDDI addresses");
 	tx_additem(menu, NULL, NULL);
 	tx_additem(menu, " E^x^it configuration", "Returns to main menu");

--- a/src/pktsize.c
+++ b/src/pktsize.c
@@ -288,10 +288,10 @@ void packet_size_breakdown(char *ifname, time_t facilitytime)
 
 	exitloop = 0;
 
-	struct timeval now;
-	gettimeofday(&now, NULL);
-	struct timeval last_time = now;
-	struct timeval last_update = now;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	struct timespec last_time = now;
+	struct timespec last_update = now;
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -303,7 +303,7 @@ void packet_size_breakdown(char *ifname, time_t facilitytime)
 		log_next = now.tv_sec + options.logspan;
 
 	while (!exitloop) {
-		gettimeofday(&now, NULL);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		if (now.tv_sec > last_time.tv_sec) {
 			printelapsedtime(now.tv_sec - starttime, 1, table.borderwin);

--- a/src/pktsize.c
+++ b/src/pktsize.c
@@ -24,6 +24,7 @@ pktsize.c	- the packet size breakdown facility
 #include "log.h"
 #include "logvars.h"
 #include "capt.h"
+#include "timer.h"
 
 #define SIZES 20
 
@@ -291,7 +292,7 @@ void packet_size_breakdown(char *ifname, time_t facilitytime)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	struct timespec last_time = now;
-	struct timespec last_update = now;
+	struct timespec next_screen_update = { 0 };
 
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
@@ -323,13 +324,13 @@ void packet_size_breakdown(char *ifname, time_t facilitytime)
 			last_time = now;
 		}
 
-		if (screen_update_needed(&now, &last_update)) {
+		if (time_after(&now, &next_screen_update)) {
 			print_size_distrib(&table);
 
 			update_panels();
 			doupdate();
 
-			last_update = now;
+			set_next_screen_update(&next_screen_update, &now);
 		}
 
 		if (capt_get_packet(&capt, &pkt, &ch, table.win) == -1) {

--- a/src/revname.c
+++ b/src/revname.c
@@ -196,13 +196,7 @@ int revname(int *lookup, struct sockaddr_storage *addr,
 			strncpy(target, rpkt.fqdn, target_size - 1);
 			return (rpkt.ready);
 		} else {
-			struct hostent *he = sockaddr_gethostbyaddr(addr);
-			if (he == NULL) {
-				sockaddr_ntop(addr, target, target_size);
-			} else {
-				strncpy(target, he->h_name, target_size - 1);
-			}
-
+			sockaddr_gethostbyaddr(addr, target, target_size);
 			return RESOLVED;
 		}
 	} else {

--- a/src/rvnamed.c
+++ b/src/rvnamed.c
@@ -83,26 +83,15 @@ static void auto_terminate(int s __unused)
 
 static void process_rvn_packet(struct rvn *rvnpacket)
 {
-	int ccfd;
+	sockaddr_gethostbyaddr(&rvnpacket->addr,
+				rvnpacket->fqdn,
+				sizeof(rvnpacket->fqdn));
+
 	struct sockaddr_un ccsa;
-
-	struct hostent *he;
-
-	ccfd = socket(PF_UNIX, SOCK_DGRAM, 0);
-
-	he = sockaddr_gethostbyaddr(&rvnpacket->addr);
-	if (he == NULL) {
-		sockaddr_ntop(&rvnpacket->addr, rvnpacket->fqdn,
-			      sizeof(rvnpacket->fqdn));
-	} else {
-		memset(rvnpacket->fqdn, 0, sizeof(rvnpacket->fqdn));
-		strncpy(rvnpacket->fqdn, he->h_name,
-			sizeof(rvnpacket->fqdn) - 1);
-	}
-
 	ccsa.sun_family = AF_UNIX;
 	strcpy(ccsa.sun_path, CHILDSOCKNAME);
 
+	int ccfd = socket(PF_UNIX, SOCK_DGRAM, 0);
 	sendto(ccfd, rvnpacket, sizeof(struct rvn), 0,
 	       (struct sockaddr *) &ccsa,
 	       sizeof(ccsa.sun_family) + strlen(ccsa.sun_path));

--- a/src/rvnamed.c
+++ b/src/rvnamed.c
@@ -40,6 +40,8 @@ socket protocol.
 #include <string.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <stdbool.h>
+
 #include "rvnamed.h"
 #include "dirs.h"
 #include "sockaddr.h"

--- a/src/serv.c
+++ b/src/serv.c
@@ -32,6 +32,7 @@ serv.c  - TCP/UDP port statistics module
 #include "counters.h"
 #include "rate.h"
 #include "capt.h"
+#include "timer.h"
 
 #define SCROLLUP 0
 #define SCROLLDOWN 1
@@ -952,7 +953,7 @@ void servmon(char *ifname, time_t facilitytime)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	struct timespec last_time = now;
-	struct timespec last_update = now;
+	struct timespec next_screen_update = { 0 };
 	time_t starttime = now.tv_sec;
 	time_t endtime = INT_MAX;
 	if (facilitytime != 0)
@@ -989,13 +990,13 @@ void servmon(char *ifname, time_t facilitytime)
 			last_time = now;
 		}
 
-		if (screen_update_needed(&now, &last_update)) {
+		if (time_after(&now, &next_screen_update)) {
 			refresh_serv_screen(&list);
 
 			update_panels();
 			doupdate();
 
-			last_update = now;
+			set_next_screen_update(&next_screen_update, &now);
 		}
 
 		if (capt_get_packet(&capt, &pkt, &ch, list.win) == -1) {

--- a/src/sockaddr.c
+++ b/src/sockaddr.c
@@ -65,8 +65,8 @@ void sockaddr_set_port(struct sockaddr_storage *sockaddr, in_port_t port)
 	}
 }
 
-int sockaddr_is_equal(struct sockaddr_storage *addr1,
-		      struct sockaddr_storage *addr2)
+bool sockaddr_is_equal(struct sockaddr_storage const *addr1,
+		       struct sockaddr_storage const *addr2)
 {
 	if (!addr1)
 		die("%s(): addr1 == NULL", __FUNCTION__);
@@ -74,7 +74,7 @@ int sockaddr_is_equal(struct sockaddr_storage *addr1,
 		die("%s(): addr2 == NULL", __FUNCTION__);
 
 	if (addr1->ss_family != addr2->ss_family)
-		return 0;
+		return false;
 
 	switch (addr1->ss_family) {
 	case AF_INET: {
@@ -83,9 +83,9 @@ int sockaddr_is_equal(struct sockaddr_storage *addr1,
 
 		if ((sa1->sin_addr.s_addr == sa2->sin_addr.s_addr)
 		    && (sa1->sin_port == sa2->sin_port))
-			return 1;
+			return true;
 		else
-			return 0;
+			return false;
 		}
 	case AF_INET6: {
 		struct sockaddr_in6 *sa1 = (struct sockaddr_in6 *)addr1;
@@ -95,9 +95,9 @@ int sockaddr_is_equal(struct sockaddr_storage *addr1,
 		    && (sa1->sin6_flowinfo == sa2->sin6_flowinfo)
 		    && (sa1->sin6_scope_id == sa2->sin6_scope_id)
 		    && (memcmp(&sa1->sin6_addr, &sa2->sin6_addr, sizeof(sa1->sin6_addr)) == 0))
-			return 1;
+			return true;
 		else
-			return 0;
+			return false;
 	       }
 	default:
 		die("%s(): Unknown address family", __FUNCTION__);

--- a/src/sockaddr.h
+++ b/src/sockaddr.h
@@ -9,8 +9,9 @@ in_port_t sockaddr_get_port(struct sockaddr_storage *sockaddr);
 void sockaddr_set_port(struct sockaddr_storage *sockaddr, in_port_t port);
 bool sockaddr_is_equal(struct sockaddr_storage const *addr1,
 		       struct sockaddr_storage const *addr2);
-void sockaddr_ntop(struct sockaddr_storage *addr, char *buf, size_t buflen);
-struct hostent *sockaddr_gethostbyaddr(struct sockaddr_storage *addr);
+void sockaddr_ntop(const struct sockaddr_storage *addr, char *buf, size_t buflen);
+void sockaddr_gethostbyaddr(const struct sockaddr_storage *addr,
+			    char *buffer, size_t buflen);
 void sockaddr_copy(struct sockaddr_storage *dest, struct sockaddr_storage *src);
 
 #endif	/* IPTRAF_NG_SOCKADDR_H */

--- a/src/sockaddr.h
+++ b/src/sockaddr.h
@@ -7,8 +7,8 @@ void sockaddr_make_ipv6(struct sockaddr_storage *sockaddr,
 			struct in6_addr *addr);
 in_port_t sockaddr_get_port(struct sockaddr_storage *sockaddr);
 void sockaddr_set_port(struct sockaddr_storage *sockaddr, in_port_t port);
-int sockaddr_is_equal(struct sockaddr_storage *addr1,
-		      struct sockaddr_storage *addr2);
+bool sockaddr_is_equal(struct sockaddr_storage const *addr1,
+		       struct sockaddr_storage const *addr2);
 void sockaddr_ntop(struct sockaddr_storage *addr, char *buf, size_t buflen);
 struct hostent *sockaddr_gethostbyaddr(struct sockaddr_storage *addr);
 void sockaddr_copy(struct sockaddr_storage *dest, struct sockaddr_storage *src);

--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -238,10 +238,27 @@ static void del_tcp_hash_node(struct tcptable *table, struct tcptableent *entry)
 	free(ptmp);
 }
 
+static void resolve_entry(struct tcptableent *entry, int *revlook, int rvnfd)
+{
+	if (entry->s_fstat != RESOLVED) {
+		entry->s_fstat = revname(revlook, &entry->saddr,
+					 entry->s_fqdn, sizeof(entry->s_fqdn),
+					 rvnfd);
+		strcpy(entry->oth_connection->d_fqdn, entry->s_fqdn);
+		entry->oth_connection->d_fstat = entry->s_fstat;
+	}
+	if (entry->d_fstat != RESOLVED) {
+		entry->d_fstat = revname(revlook, &entry->daddr,
+					 entry->d_fqdn, sizeof(entry->d_fqdn),
+					 rvnfd);
+		strcpy(entry->oth_connection->s_fqdn, entry->d_fqdn);
+		entry->oth_connection->s_fstat = entry->d_fstat;
+	}
+}
+
 /*
  * Add a new entry to the TCP screen table
  */
-
 struct tcptableent *addentry(struct tcptable *table,
 			     struct sockaddr_storage *saddr,
 			     struct sockaddr_storage *daddr,
@@ -365,13 +382,9 @@ struct tcptableent *addentry(struct tcptable *table,
 
 	new_entry->stat = new_entry->oth_connection->stat = 0;
 
-	new_entry->s_fstat =
-	    revname(rev_lookup, &new_entry->saddr,
-		    new_entry->s_fqdn, sizeof(new_entry->s_fqdn), rvnfd);
-
-	new_entry->d_fstat =
-	    revname(rev_lookup, &new_entry->daddr,
-		    new_entry->d_fqdn, sizeof(new_entry->d_fqdn), rvnfd);
+	new_entry->s_fstat = NOTRESOLVED;
+	new_entry->d_fstat = NOTRESOLVED;
+	resolve_entry(new_entry, rev_lookup, rvnfd);
 
 	/* set port service names (where applicable) */
 	servlook(sockaddr_get_port(saddr), IPPROTO_TCP, new_entry->s_sname, 10);
@@ -562,20 +575,8 @@ void updateentry(struct tcptable *table, struct pkt_hdr *pkt,
 	char msgstring[MSGSTRING_MAX];
 	char newmacaddr[18];
 
-	if (tableentry->s_fstat != RESOLVED) {
-		tableentry->s_fstat =
-		    revname(revlook, &tableentry->saddr, tableentry->s_fqdn,
-			    sizeof(tableentry->s_fqdn), rvnfd);
-		strcpy(tableentry->oth_connection->d_fqdn, tableentry->s_fqdn);
-		tableentry->oth_connection->d_fstat = tableentry->s_fstat;
-	}
-	if (tableentry->d_fstat != RESOLVED) {
-		tableentry->d_fstat =
-		    revname(revlook, &tableentry->daddr, tableentry->d_fqdn,
-			    sizeof(tableentry->d_fqdn), rvnfd);
-		strcpy(tableentry->oth_connection->s_fqdn, tableentry->d_fqdn);
-		tableentry->oth_connection->s_fstat = tableentry->d_fstat;
-	}
+	resolve_entry(tableentry, revlook, rvnfd);
+
 	tableentry->pcount++;
 	tableentry->bcount += bcount;
 	tableentry->psize = pkt->pkt_len;
@@ -866,6 +867,20 @@ void printentry(struct tcptable *table, struct tcptableent *tableentry)
 	wmove(table->tcpscreen, target_row, 70 * COLS / 80);
 	wprintw(table->tcpscreen, "%-*.*s", table->ifnamew, table->ifnamew,
 		tableentry->ifname);
+}
+
+void resolve_visible_entries(struct tcptable *table, int *revlook, int rvnfd)
+{
+
+	if(!*revlook)
+		return;
+
+	struct tcptableent *entry = table->firstvisible;
+	while ((entry != NULL) && (entry->prev_entry != table->lastvisible)) {
+		resolve_entry(entry, revlook, rvnfd);
+
+		entry = entry->next_entry;
+	}
 }
 
 /*

--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -266,6 +266,7 @@ struct tcptableent *addentry(struct tcptable *table,
 			table->head = new_entry;
 
 			table->firstvisible = new_entry;
+			table->barptr = new_entry;
 		}
 		if (table->tail != NULL) {
 			table->tail->next_entry = new_entry;

--- a/src/tcptable.h
+++ b/src/tcptable.h
@@ -129,11 +129,9 @@ void updateentry(struct tcptable *table, struct pkt_hdr *pkt,
 
 void addtoclosedlist(struct tcptable *table, struct tcptableent *tableentry);
 
-void clearaddr(struct tcptable *table, struct tcptableent *tableentry);
-
 void printentry(struct tcptable *table, struct tcptableent *tableentry);
 
-void refreshtcpwin(struct tcptable *table);
+void refreshtcpwin(struct tcptable *table, bool clear);
 
 void destroytcptable(struct tcptable *table);
 

--- a/src/tcptable.h
+++ b/src/tcptable.h
@@ -131,6 +131,7 @@ void addtoclosedlist(struct tcptable *table, struct tcptableent *tableentry);
 
 void printentry(struct tcptable *table, struct tcptableent *tableentry);
 
+void resolve_visible_entries(struct tcptable *table, int *revlook, int rvnfd);
 void refreshtcpwin(struct tcptable *table, bool clear);
 
 void destroytcptable(struct tcptable *table);

--- a/src/timer.c
+++ b/src/timer.c
@@ -9,6 +9,7 @@ timer.c		- module to display the elapsed time since a facility
 ***/
 
 #include "iptraf-ng-compat.h"
+#include "timer.h"
 
 void printelapsedtime(time_t elapsed, int x, WINDOW *win)
 {
@@ -18,4 +19,31 @@ void printelapsedtime(time_t elapsed, int x, WINDOW *win)
 	int y = getmaxy(win) - 1;
 
 	mvwprintw(win, y, x, " Time: %3u:%02u ", hours, mins);
+}
+
+inline bool time_after(struct timespec const *a, struct timespec const *b)
+{
+	if (a->tv_sec > b->tv_sec)
+		return true;
+	if (a->tv_sec < b->tv_sec)
+		return false;
+	if(a->tv_nsec > b->tv_nsec)
+		return true;
+	else
+		return false;
+}
+
+void time_add_msecs(struct timespec *time, unsigned int msecs)
+{
+	if (time != NULL) {
+		while (msecs >= 1000) {
+			time->tv_sec++;
+			msecs -= 1000;
+		}
+		time->tv_nsec += msecs * 1000000;
+		while (time->tv_nsec >= 1000000000) {
+			time->tv_sec++;
+			time->tv_nsec -= 1000000000;
+		}
+	}
 }

--- a/src/timer.h
+++ b/src/timer.h
@@ -2,5 +2,7 @@
 #define IPTRAF_NG_TIMER_H
 
 void printelapsedtime(time_t elapsed, int x, WINDOW *win);
+bool time_after(struct timespec const *a, struct timespec const *b);
+void time_add_msecs(struct timespec *time, unsigned int msecs);
 
 #endif	/* IPTRAF_NG_TIMER_H */


### PR DESCRIPTION
- use clock_gettime() instead of gettimeofday()
- remove unused dispmode() macro
- change screen_update_needed() to time_after()
- hostmon(): honor screen update rate when printing traffic rates
- fix TPACKET_V3 statistics
- change return type of capt->have_packet() to bool
- change return type of sockaddr_is_equal() to bool
- ipmon(): set barptr to newly added tcpentry if this is the first one in the table
- options.c: Token Ring is long gone ...
- use thread-safe getnameinfo() instead of gethostbyaddr()
- optimization: ipmon(): update screen only when needed
- ipmon(): fetch async-resolved names every second and not only when the flow is updated
