### PR TITLE
fix: rvnamed.c: check only address part of sockaddr_storage

### DIFF
--- a/src/rvnamed.c
+++ b/src/rvnamed.c
@@ -107,7 +107,7 @@ static int name_resolved(struct rvn *rvnpacket, struct hosts *hostlist,
 {
 	for (unsigned int i = 0; i != lastfree; i++)
 		if ((hostlist[i].ready == RESOLVED)
-		    && sockaddr_is_equal(&rvnpacket->addr, &hostlist[i].addr))
+		    && sockaddr_addr_is_equal(&rvnpacket->addr, &hostlist[i].addr))
 			return i;
 
 	return -1;
@@ -122,7 +122,7 @@ static int addrstat(struct rvn *rvnpacket, struct hosts *hostlist,
 		    unsigned int lastfree)
 {
 	for (unsigned int i = 0; i != lastfree; i++)
-		if (sockaddr_is_equal(&rvnpacket->addr, &hostlist[i].addr))
+		if (sockaddr_addr_is_equal(&rvnpacket->addr, &hostlist[i].addr))
 			return hostlist[i].ready;
 
 	return NOTRESOLVED;
@@ -271,7 +271,7 @@ int main(void)
 				hi = 0;
 
 				while (hi <= lastfree) {
-					if (sockaddr_is_equal(&hostlist[hi].addr, &rvnpacket.addr))
+					if (sockaddr_addr_is_equal(&hostlist[hi].addr, &rvnpacket.addr))
 						break;
 					hi++;
 				}

--- a/src/sockaddr.h
+++ b/src/sockaddr.h
@@ -9,6 +9,8 @@ in_port_t sockaddr_get_port(struct sockaddr_storage *sockaddr);
 void sockaddr_set_port(struct sockaddr_storage *sockaddr, in_port_t port);
 bool sockaddr_is_equal(struct sockaddr_storage const *addr1,
 		       struct sockaddr_storage const *addr2);
+bool sockaddr_addr_is_equal(struct sockaddr_storage const *addr1,
+			    struct sockaddr_storage const *addr2);
 void sockaddr_ntop(const struct sockaddr_storage *addr, char *buf, size_t buflen);
 void sockaddr_gethostbyaddr(const struct sockaddr_storage *addr,
 			    char *buffer, size_t buflen);


### PR DESCRIPTION
In struct sockaddr_storage there are other fields (e.g. TCP/UDP port, IPv6 flowid, etc.) which we must
not check in reverse name resolver code - we just need to check address only.

Fixes: ba0bbe958fe6 ("use sockaddr_*() helpers for addresses")
Signed-off-by: Vitezslav Samel <vitezslav@samel.cz>