### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ VERSION-FILE: FORCE
 	@$(SHELL_PATH) ./GEN-VERSION-FILE
 -include VERSION-FILE
 
-CFLAGS = -g -O2 -Wall -W -std=gnu99 -Werror=format-security -D_GNU_SOURCE
+CFLAGS = -g -O2 -Wall -W -Werror=format-security
 LDFLAGS =
-ALL_CFLAGS = $(CPPFLAGS) $(CFLAGS)
+IPTRAF_CFLAGS := -std=gnu99 -D_GNU_SOURCE
+ALL_CFLAGS = $(CPPFLAGS) $(CFLAGS) $(IPTRAF_CFLAGS)
 ALL_LDFLAGS = $(LDFLAGS)
 STRIP ?= strip
 

--- a/src/capt-mmap-v2.c
+++ b/src/capt-mmap-v2.c
@@ -102,14 +102,17 @@ static void capt_cleanup_mmap_v2(struct capt *capt)
 
 int capt_setup_mmap_v2(struct capt *capt)
 {
+	if (capt_get_socket(capt) == -1)
+		return -1;
+
 	int version = TPACKET_V2;
 	if (setsockopt(capt->fd, SOL_PACKET, PACKET_VERSION, &version, sizeof(version)) != 0)
-		return -1;
+		goto err;
 
 	int hdrlen = version;
 	socklen_t socklen = sizeof(hdrlen);
 	if (getsockopt(capt->fd, SOL_PACKET, PACKET_HDRLEN, &hdrlen, &socklen) != 0)
-		return -1;
+		goto err;
 
 	struct tpacket_req req;
 
@@ -119,16 +122,16 @@ int capt_setup_mmap_v2(struct capt *capt)
 	req.tp_block_size = req.tp_frame_nr * req.tp_frame_size;
 
 	if(setsockopt(capt->fd, SOL_PACKET, PACKET_RX_RING, &req, sizeof(req)) != 0)
-		return -1;
+		goto err;
 
 	size_t size = req.tp_block_size * req.tp_block_nr;
 	void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, capt->fd, 0);
 	if (map == MAP_FAILED)
-		return -1;
+		goto err;
 
 	if(mlock(map, size) != 0) {
 		munmap(map, size);
-		return -1;
+		goto err;
 	}
 
 	struct capt_data_mmap_v2 *data = xmallocz(sizeof(struct capt_data_mmap_v2));
@@ -151,4 +154,7 @@ int capt_setup_mmap_v2(struct capt *capt)
 	capt->cleanup		= capt_cleanup_mmap_v2;
 
 	return 0;	/* All O.K. */
+err:
+	capt_put_socket(capt);
+	return -1;
 }

--- a/src/capt-mmap-v2.c
+++ b/src/capt-mmap-v2.c
@@ -121,7 +121,7 @@ int capt_setup_mmap_v2(struct capt *capt)
 	req.tp_frame_size = FRAME_SIZE;
 	req.tp_block_size = req.tp_frame_nr * req.tp_frame_size;
 
-	if(setsockopt(capt->fd, SOL_PACKET, PACKET_RX_RING, &req, sizeof(req)) != 0)
+	if (setsockopt(capt->fd, SOL_PACKET, PACKET_RX_RING, &req, sizeof(req)) != 0)
 		goto err;
 
 	size_t size = req.tp_block_size * req.tp_block_nr;
@@ -129,10 +129,10 @@ int capt_setup_mmap_v2(struct capt *capt)
 	if (map == MAP_FAILED)
 		goto err;
 
-	if(mlock(map, size) != 0) {
-		munmap(map, size);
-		goto err;
-	}
+	/* try to lock this memory to RAM */
+	(void)mlock(map, size);	/* no need to check return value because the mlock() is
+				 * not mandatory; if it fails packet capture just works OK
+				 * albeit suboptimally */
 
 	struct capt_data_mmap_v2 *data = xmallocz(sizeof(struct capt_data_mmap_v2));
 

--- a/src/capt-mmap-v3.c
+++ b/src/capt-mmap-v3.c
@@ -172,10 +172,10 @@ int capt_setup_mmap_v3(struct capt *capt)
 	if (map == MAP_FAILED)
 		goto err;
 
-	if (mlock(map, size) != 0) {
-		munmap(map, size);
-		goto err;
-	}
+	/* try to lock this memory to RAM */
+	(void)mlock(map, size);	/* no need to check return value because the mlock() is
+				 * not mandatory; if it fails packet capture just works OK
+				 * albeit suboptimally */
 
 	struct capt_data_mmap_v3 *data = xmallocz(sizeof(struct capt_data_mmap_v3));
 

--- a/src/capt-recvmmsg.c
+++ b/src/capt-recvmmsg.c
@@ -114,6 +114,9 @@ int capt_setup_recvmmsg(struct capt *capt)
 {
 	struct capt_data_recvmmsg *data;
 
+	if (capt_get_socket(capt) == -1)
+		return -1;
+
 	data			= xmallocz(sizeof(struct capt_data_recvmmsg));
 	data->buf		= xmallocz(FRAMES * MAX_PACKET_SIZE);
 	data->msgvec		= xmallocz(FRAMES * sizeof(*data->msgvec));

--- a/src/capt-recvmsg.c
+++ b/src/capt-recvmsg.c
@@ -64,8 +64,12 @@ static void capt_cleanup_recvmsg(struct capt *capt)
 
 int capt_setup_recvmsg(struct capt *capt)
 {
-	struct capt_data_recvmsg *data = xmallocz(sizeof(struct capt_data_recvmsg));
+	struct capt_data_recvmsg *data;
 
+	if (capt_get_socket(capt) == -1)
+		return -1;
+
+	data			= xmallocz(sizeof(struct capt_data_recvmsg));
 	data->buf		= xmallocz(MAX_PACKET_SIZE);
 	data->iov.iov_len	= MAX_PACKET_SIZE;
 	data->iov.iov_base	= data->buf;

--- a/src/capt.h
+++ b/src/capt.h
@@ -27,6 +27,8 @@ struct capt {
 	void		(*cleanup)(struct capt *capt);
 };
 
+int capt_get_socket(struct capt *capt);
+void capt_put_socket(struct capt *capt);
 int capt_init(struct capt *capt, char *ifname);
 void capt_destroy(struct capt *capt);
 unsigned long capt_get_dropped(struct capt *capt);


### PR DESCRIPTION
Fix problems reported by @jengelh:
- Makefile: protect mandatory compile flags
- packet capture: don't reuse socket for multiple receive functions
- TPACKET_V[23]: continue even if mlock() fails