### PR TITLE
Fix file not found issue during cross compilation

### DIFF
--- a/src/tui/input.c
+++ b/src/tui/input.c
@@ -7,7 +7,7 @@ input.c - a custom keyboard input module
 
 ***/
 
-#include "iptraf-ng-compat.h"
+#include "../iptraf-ng-compat.h"
 
 #include "input.h"
 

--- a/src/tui/labels.c
+++ b/src/tui/labels.c
@@ -6,7 +6,7 @@
  * user interface library
  */
 
-#include "iptraf-ng-compat.h"
+#include "../iptraf-ng-compat.h"
 
 #include "winops.h"
 

--- a/src/tui/listbox.c
+++ b/src/tui/listbox.c
@@ -5,7 +5,7 @@
  * listbox.c - scrollable listbox management module
  */
 
-#include "iptraf-ng-compat.h"
+#include "../iptraf-ng-compat.h"
 
 #include "winops.h"
 #include "labels.h"

--- a/src/tui/menurt.c
+++ b/src/tui/menurt.c
@@ -7,7 +7,7 @@ menurt.c - ncurses-based menu definition module
 
 ***/
 
-#include "iptraf-ng-compat.h"
+#include "../iptraf-ng-compat.h"
 
 #include "menurt.h"
 #include "winops.h"

--- a/src/tui/msgboxes.c
+++ b/src/tui/msgboxes.c
@@ -5,7 +5,7 @@
  * msgboxes.c - message and error box display functions
  */
 
-#include "iptraf-ng-compat.h"
+#include "../iptraf-ng-compat.h"
 
 #include "winops.h"
 

--- a/src/tui/winops.c
+++ b/src/tui/winops.c
@@ -7,7 +7,7 @@ winops.c - screen configuration and setup functions
 
 ***/
 
-#include "iptraf-ng-compat.h"
+#include "../iptraf-ng-compat.h"
 
 void tx_stdwinset(WINDOW * win)
 {


### PR DESCRIPTION
Iptraf-ng needs to be upgraded on buildroot (which stills uses 1.1.4 release) in order to run on embedded devices. However, when cross compiled, files in src/tui folder include directly iptraf-ng-compat.h which is in the parent directory which yields to : "iptraf-ng-compat.h" no such file or directory.

The inclusion must be explicit in order for the compilation to work properly on every setup.