### PR TITLE
use XDP to count packets

### DIFF
--- a/src/capt.c
+++ b/src/capt.c
@@ -139,6 +139,25 @@ unsigned long capt_get_dropped(struct capt *capt)
 	return capt_get_dropped_generic(capt);
 }
 
+int capt_get_char(WINDOW *win)
+{
+	struct pollfd pfds[] = { {
+		.fd = 0,
+		.events = POLLIN,
+	} };
+	int ss;
+
+	if (daemonized)
+		return 1;
+
+	ss = poll(pfds, 1, DEFAULT_UPDATE_DELAY);
+
+	if (ss && pfds[0].revents & POLLIN)
+		return wgetch(win);
+
+	return ERR;
+}
+
 int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win)
 {
 	struct pollfd pfds[2];

--- a/src/capt.h
+++ b/src/capt.h
@@ -32,6 +32,7 @@ void capt_put_socket(struct capt *capt);
 int capt_init(struct capt *capt, char *ifname);
 void capt_destroy(struct capt *capt);
 unsigned long capt_get_dropped(struct capt *capt);
+int capt_get_char(WINDOW *win);
 int capt_get_packet(struct capt *capt, struct pkt_hdr *pkt, int *ch, WINDOW *win);
 int capt_put_packet(struct capt *capt, struct pkt_hdr *pkt);
 

--- a/src/det_bpf.c
+++ b/src/det_bpf.c
@@ -1,0 +1,133 @@
+/*
+ * bptraf - eBPF traffic analyzer
+ * inspired by Linux kernel xdp1 example
+ * Copyright (C) 2020 Matteo Croce <mcroce@microsoft.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <arpa/inet.h>
+#include <asm/byteorder.h>
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+
+#include "det_bpf.h"
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+struct bpf_map_def {
+	unsigned int type;
+	unsigned int key_size;
+	unsigned int value_size;
+	unsigned int max_entries;
+	unsigned int map_flags;
+	unsigned int inner_map_idx;
+	unsigned int numa_node;
+};
+
+struct bpf_map_def SEC("maps") traf = {
+	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size = sizeof(unsigned),
+	.value_size = sizeof(struct trafdata),
+	.max_entries = _MAX_PROTO,
+};
+
+static void *(*bpf_map_lookup_elem)(void *map, void *key) =
+	(void *) BPF_FUNC_map_lookup_elem;
+
+static void inc_stats(unsigned key, int len)
+{
+	struct trafdata *val = bpf_map_lookup_elem(&traf, &key);
+
+	if (val) {
+		val->packets++;
+		val->bytes += len;
+	}
+}
+
+static enum protocols parse_eth(uint16_t type)
+{
+	switch (type) {
+	case ETH_P_IP:
+		return IPV4;
+	case ETH_P_IPV6:
+		return IPV6;
+	}
+
+	return NON_IP;
+}
+
+static enum protocols parse_ip(uint8_t proto)
+{
+	switch (proto) {
+	case IPPROTO_ICMP:
+		return ICMP;
+	case IPPROTO_TCP:
+		return TCP;
+	case IPPROTO_UDP:
+		return UDP;
+	}
+
+	return OTHER_IP;
+}
+
+SEC("prog")
+int xdp_main(struct xdp_md *ctx)
+{
+	void *data_end = (void *)(uintptr_t)ctx->data_end;
+	void *data = (void *)(uintptr_t)ctx->data;
+	const size_t plen = data_end - data + 1;
+	uint16_t ethproto;
+	struct ethhdr *eth = data;
+
+	/* sanity check needed by the eBPF verifier */
+	if ((void *)(eth + 1) > data_end)
+		return XDP_PASS;
+
+	ethproto = __constant_ntohs(eth->h_proto);
+
+	inc_stats(TOTAL, plen);
+	inc_stats(parse_eth(ethproto), plen - sizeof(*eth));
+	if (eth->h_dest[0] & 1)
+		inc_stats(BROADCAST, plen);
+
+	switch (ethproto) {
+	case ETH_P_IP: {
+		struct iphdr *iph = (struct iphdr *)(eth + 1);
+
+		if ((void *)(iph + 1) > data_end)
+			break;
+
+		inc_stats(parse_ip(iph->protocol), plen - sizeof(*iph));
+		break;
+	}
+	case ETH_P_IPV6: {
+		struct ipv6hdr *ip6h = (struct ipv6hdr *)(eth + 1);
+
+		if ((void *)(ip6h + 1) > data_end)
+			break;
+
+		inc_stats(parse_ip(ip6h->nexthdr), plen - sizeof(*ip6h));
+		break;
+	}
+	}
+
+	return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/src/det_bpf.h
+++ b/src/det_bpf.h
@@ -1,0 +1,28 @@
+#ifndef DET_BPF_H
+#define DET_BPF_H
+
+enum protocols {
+	/* all */
+	TOTAL,
+	BROADCAST,
+
+	/* L3 */
+	IPV4,
+	IPV6,
+	NON_IP,
+
+	/* L4 */
+	ICMP,
+	TCP,
+	UDP,
+	OTHER_IP,
+
+	_MAX_PROTO,
+};
+
+struct trafdata {
+	uint64_t packets;
+	uint64_t bytes;
+};
+
+#endif

--- a/src/dirs.h
+++ b/src/dirs.h
@@ -27,6 +27,10 @@
 #define LOGDIR		"/var/log/iptraf-ng"
 #endif
 
+#ifndef SHAREDIR
+#define SHAREDIR	PREFIX "/share/iptraf-ng"
+#endif
+
 /*
  * Lock directory.
  * 
@@ -87,6 +91,7 @@
 #define ITRAFMONCOUNTFILE 	get_path(T_LOCKDIR, "iptraf-itrafmoncount.dat")
 #define LANMONCOUNTFILE		get_path(T_LOCKDIR, "iptraf-lanmoncount.dat")
 #define PROMISCLISTFILE 	get_path(T_WORKDIR, "iptraf-promisclist.tmp")
+#define DETBPF_FILE		get_path(T_SHAREDIR, "det_bpf.o")
 
 #define OTHIPFLNAME	get_path(T_WORKDIR, "othipfilters.dat")
 

--- a/src/getpath.c
+++ b/src/getpath.c
@@ -25,11 +25,14 @@ char *get_path(int dirtype, char *file)
 	case T_LOCKDIR:
 		dir = LOCKDIR;
 		break;
+	case T_SHAREDIR:
+		dir = SHAREDIR;
+		break;
 	default:
 		return file;
 	}
 
-	if ((dirtype != T_LOCKDIR) && (ptr = getenv(env)) != NULL)
+	if ((dirtype != T_LOCKDIR && dirtype != T_SHAREDIR) && (ptr = getenv(env)) != NULL)
 		dir = ptr;
 
 	if (dir == NULL || *dir == '\0')

--- a/src/getpath.h
+++ b/src/getpath.h
@@ -5,6 +5,7 @@
 #define T_LOGDIR	2
 #define T_EXECDIR	3
 #define T_LOCKDIR	4
+#define T_SHAREDIR	5
 
 char *get_path(int dirtype, char *file);
 

--- a/src/iptraf.c
+++ b/src/iptraf.c
@@ -256,7 +256,7 @@ static const char *const iptraf_ng_usage[] = {
 	NULL
 };
 
-static int help_opt, f_opt, g_opt, facilitytime, B_opt;
+static int help_opt, f_opt, g_opt, facilitytime, b_opt, B_opt;
 static char *i_opt, *d_opt, *s_opt, *z_opt, *l_opt, *L_opt;
 
 static struct options iptraf_ng_options[] = {
@@ -274,6 +274,8 @@ static struct options iptraf_ng_options[] = {
 		   "start the LAN station monitor (use '-l all' for all LAN interfaces)"),
 	OPT_BOOL('g', NULL, &g_opt, "start the general interface statistics"),
 	OPT_GROUP(""),
+	OPT_BOOL('b', NULL, &b_opt,
+		 "use XDP to gather packet statistics (only incoming traffic will work)"),
 	OPT_BOOL('B', NULL, &B_opt,
 		 "run in background (use only with one of the above parameters"),
 	OPT_BOOL('f', NULL, &f_opt,
@@ -394,6 +396,9 @@ int main(int argc, char **argv)
 		removetags();
 		remove_sockets();
 	}
+
+	if (b_opt)
+		options.bpf = 1;
 
 	if (B_opt) {
 		if (!command)

--- a/src/options.h
+++ b/src/options.h
@@ -3,7 +3,7 @@
 
 struct OPTIONS {
 	unsigned int color:1, logging:1, revlook:1, servnames:1, promisc:1,
-	    actmode:1, mac:1, v6inv4asv6:1, dummy:8;
+	    actmode:1, mac:1, v6inv4asv6:1, bpf:1, dummy:7;
 	time_t timeout;
 	time_t logspan;
 	time_t updrate;


### PR DESCRIPTION
Add a '-b' option to count packets using an eBPF program instead of
an AF_PACKET socket in the detailed interface statistics mode.
When enabled, an eBPF will be attached to the interface and populate
a map with protocol statistics.
Then, iptraf-ng will read the map every DEFAULT_UPDATE_DELAY msecs
and update the panel.

The advantage is that the AF_PACKET socket has a big overhead because
it has to clone every packet and copy it to userspace.
With a fast link this overhead will become noticeable: iptraf-ng drops
packets and network traffic is severely impacted.
XDP instead can handle millions of packets per seconds without noticeable
effect on traffic.

This was tested on a 10 Gbit link filled with little less than 14 millions
of packets per second. The classic implementation capped at 111k pps with
both ksoftirqd and iptraf-ng stuck at 100% CPU usage. Network traffic was
fluctuating between -50% and -66%.
With the XDP program, all the traffic was correctly counted, iptraf-ng
CPU usage was almost 0%, and ksoftirqd oscillating in the 2-4% range.
Network traffic was not affected at all.

An asciinema recording of the session is here: https://asciinema.org/a/207160

The drawback of the XDP implementation is that only incoming traffic
is seen, since XDP doesn't handle outgoing traffic.

Signed-off-by: Matteo Croce <mcroce@microsoft.com>