### PR TITLE
Cure sort function crash when itrafmon has no entries

### DIFF
--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -991,7 +991,7 @@ void flushclosedentries(struct tcptable *table)
 	struct tcptableent *ptmp = table->head;
 	struct tcptableent *ctmp = NULL;
 	unsigned long idx = 1;
-	unsigned long screen_idx = table->firstvisible->index;
+	unsigned long screen_idx = table->firstvisible == NULL ? 0 : table->firstvisible->index;
 
 	while (ptmp != NULL) {
 		if (ptmp->inclosed) {


### PR DESCRIPTION
Pick "IP traffic monitor", pick some interface with no activity, hit keys 'S' (Sort), any key (p/b/other). This leads to a NULL derefence. Fix it.

Fixes: v1.1.4-62-g8e89047