### PR TITLE
Add GeoIP country code display for TCP traffic monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,14 @@ VERSION-FILE: FORCE
 -include VERSION-FILE
 
 CFLAGS = -g -O2 -Wall -W -Werror=format-security
-LDFLAGS =
 IPTRAF_CFLAGS := -std=gnu99 -D_GNU_SOURCE
 ALL_CFLAGS = $(CPPFLAGS) $(CFLAGS) $(IPTRAF_CFLAGS)
-ALL_LDFLAGS = $(LDFLAGS)
+ALL_LDFLAGS =
+BASIC_LDFLAGS =
 STRIP ?= strip
+
+prefix = $(HOME)
+sbindir_relative = sbin
 
 prefix = $(HOME)
 sbindir_relative = sbin
@@ -52,7 +55,7 @@ TAR = tar
 # be built by a different compiler. (Note that this is an artifact now
 # but it still might be nice to keep that distinction.)
 BASIC_CFLAGS = -I. -Isrc/
-BASIC_LDFLAGS =
+BASIC_LDFLAGS = -lmaxminddb
 
 # Guard against environment variables
 iptraf-h :=
@@ -144,6 +147,8 @@ iptraf-o += src/wrapper.o
 iptraf-o += src/parse-options.o
 iptraf-o += src/packet.o
 iptraf-o += src/tcptable.o
+iptraf-o += src/geoip.o
+
 iptraf-o += src/othptab.o
 iptraf-o += src/ifstats.o
 iptraf-o += src/detstats.o

--- a/README.geoip
+++ b/README.geoip
@@ -1,0 +1,68 @@
+========================================================================
+README DOCUMENT FOR GEOIP COUNTRY CODE DISPLAY
+--------------------------------------------------------------------
+
+DESCRIPTION
+-----------
+
+IPTraf-ng can resolve IP addresses to their country of origin in the TCP
+traffic monitor panel. Country codes (e.g. [US], [DE], [RU]) are displayed
+next to host names in TCP connection entries. This feature uses the
+MaxMind GeoLite2-Country database.
+
+When enabled, the TCP traffic monitor will display IP addresses with their
+country code at the beginning of the line:
+
+    [US] 12.34.56.78:443
+    [DE] 203.0.113.15:22
+    [FR] 198.51.100.5:80
+
+
+REQUIREMENTS
+------------
+
+- libmaxminddb package installed on the system
+- GeoLite2-Country.mmdb database file present
+
+The default database path is:
+
+    /usr/share/GeoIP/GeoLite2-Country.mmdb
+
+The database file is not included with iptraf-ng. It can be downloaded
+free of charge from:
+
+    https://dev.maxmind.com/geoip/geoip2/geolite2/
+
+A free registration is required. Place the downloaded GeoLite2-Country.mmdb
+file at the default path, or install it via your distribution's package
+manager if available (e.g., geoipupdate package).
+
+
+AVAILABILITY
+------------
+
+The GeoIP feature is disabled by default. It must be enabled in the
+Configure menu before starting a traffic monitor session.
+
+If the database file is missing or unreadable, geoip_init() silently fails
+and no country codes are displayed. No crash or error occurs; the traffic
+monitor continues to function normally.
+
+
+ENABLING THE FEATURE
+---------------------
+
+Run iptraf-ng as root, then:
+
+    Configure -> G (Show GeoIP country codes) -> On -> Exit
+
+When enabled, country codes will appear in subsequent TCP traffic monitor
+sessions until the setting is toggled off.
+
+
+DATABASE FORMAT
+---------------
+
+IPTraf-ng uses the MMDB (MaxMind Database) binary format. The older
+GeoIP (dat) format is not supported. Only GeoLite2-Country.mmdb or
+GeoCountry2.mmdb files are compatible.

--- a/src/geoip.c
+++ b/src/geoip.c
@@ -1,0 +1,79 @@
+#include "geoip.h"
+
+#include <maxminddb.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+static MMDB_s mmdb;
+static bool available = false;
+
+bool geoip_init(const char *db_path)
+{
+    struct stat st;
+
+    if (stat(db_path, &st) != 0)
+        return false;
+
+    if (!S_ISREG(st.st_mode))
+        return false;
+
+    int status = MMDB_open(db_path, MMDB_MODE_MMAP, &mmdb);
+    if (status != MMDB_SUCCESS) {
+        available = false;
+        return false;
+    }
+
+    available = true;
+    return true;
+}
+
+void geoip_destroy(void)
+{
+    if (available) {
+        MMDB_close(&mmdb);
+        available = false;
+    }
+}
+
+bool geoip_is_available(void)
+{
+    return available;
+}
+
+int geoip_get_country_code(struct sockaddr_storage *addr, char *code, size_t len)
+{
+    if (!available || !addr || !code || len < 3)
+        return -1;
+
+    int mmdb_error;
+
+    MMDB_lookup_result_s result = MMDB_lookup_sockaddr(&mmdb, (struct sockaddr *)addr, &mmdb_error);
+    if (mmdb_error != MMDB_SUCCESS)
+        return -1;
+
+    if (!result.found_entry)
+        return -1;
+
+    MMDB_entry_data_s entry_data;
+    int status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+    if (status != MMDB_SUCCESS)
+        return -1;
+
+    if (!entry_data.has_data)
+        return -1;
+
+    if (entry_data.type != MMDB_DATA_TYPE_UTF8_STRING)
+        return -1;
+
+    size_t copy_len = entry_data.data_size;
+    if (copy_len >= len)
+        copy_len = len - 1;
+
+    memcpy(code, entry_data.utf8_string, copy_len);
+    code[copy_len] = '\0';
+
+    return 0;
+}

--- a/src/geoip.h
+++ b/src/geoip.h
@@ -1,0 +1,16 @@
+#ifndef IPTRAF_NG_GEOIP_H
+#define IPTRAF_NG_GEOIP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+struct sockaddr_storage;
+
+bool geoip_init(const char *db_path);
+void geoip_destroy(void);
+bool geoip_is_available(void);
+int geoip_get_country_code(struct sockaddr_storage *addr, char *code, size_t len);
+
+#endif

--- a/src/itrafmon.c
+++ b/src/itrafmon.c
@@ -28,6 +28,7 @@ itrafmon.c - the IP traffic monitor module
 #include "timer.h"
 #include "ipfrag.h"
 #include "logvars.h"
+#include "geoip.h"
 #include "itrafmon.h"
 #include "sockaddr.h"
 #include "capt.h"
@@ -776,6 +777,8 @@ void ipmon(time_t facilitytime, char *ifptr)
 
 	resolver_init(&res, options.revlook);
 
+	geoip_init("/usr/share/GeoIP/GeoLite2-Country.mmdb");
+
 	if (options.servnames)
 		setservent(1);
 	setprotoent(1);
@@ -934,6 +937,7 @@ void ipmon(time_t facilitytime, char *ifptr)
 		endservent();
 
 	resolver_destroy(&res);
+	geoip_destroy();
 
 	capt_destroy(&capt);
 }

--- a/src/options.c
+++ b/src/options.c
@@ -47,6 +47,8 @@ static void makeoptionmenu(struct MENU *menu)
 		   "Toggles display of source MAC addresses in the IP Traffic Monitor");
 	tx_additem(menu, " ^S^how v6-in-v4 traffic as IPv6",
 		   "Toggled display of IPv6 tunnel in IPv4 as IPv6 traffic");
+	tx_additem(menu, " Show ^G^eoIP country codes",
+		   "Toggles display of country codes for IP addresses");
 	tx_additem(menu, NULL, NULL);
 	tx_additem(menu, " ^T^imers...", "Configures timeouts and intervals");
 	tx_additem(menu, NULL, NULL);
@@ -121,6 +123,9 @@ static void indicatesetting(int row, WINDOW *win)
 		break;
 	case 8:
 		printoptonoff(options.v6inv4asv6, win);
+		break;
+	case 9:
+		printoptonoff(options.geoip, win);
 	}
 
 }
@@ -179,17 +184,17 @@ void loadoptions(void)
 static void updatetimes(WINDOW *win)
 {
 	wattrset(win, HIGHATTR);
-	mvwprintw(win, 10, 25, "%3ld mins", options.timeout);
-	mvwprintw(win, 11, 25, "%3ld mins", options.logspan / 60);
-	mvwprintw(win, 12, 25, "%3ld secs", options.updrate);
-	mvwprintw(win, 13, 25, "%3ld mins", options.closedint);
+	mvwprintw(win, 12, 25, "%3ld mins", options.timeout);
+	mvwprintw(win, 13, 25, "%3ld mins", options.logspan / 60);
+	mvwprintw(win, 14, 25, "%3ld secs", options.updrate);
+	mvwprintw(win, 15, 25, "%3ld mins", options.closedint);
 }
 
 static void showoptions(WINDOW *win)
 {
 	int i;
 
-	for (i = 1; i <= 8; i++)
+	for (i = 1; i <= 9; i++)
 		indicatesetting(i, win);
 
 	updatetimes(win);
@@ -263,13 +268,13 @@ void setoptions(void)
 
 	makeoptionmenu(&menu);
 
-	statwin = newwin(15, 35, (LINES - 19) / 2 - 1, (COLS - 40) / 16 + 40);
+	statwin = newwin(17, 35, (LINES - 19) / 2 - 1, (COLS - 40) / 16 + 40);
 	statpanel = new_panel(statwin);
 
 	wattrset(statwin, BOXATTR);
 	tx_colorwin(statwin);
 	tx_box(statwin, ACS_VLINE, ACS_HLINE);
-	wmove(statwin, 9, 1);
+	wmove(statwin, 10, 1);
 	whline(statwin, ACS_HLINE, 33);
 	mvwprintw(statwin, 0, 1, " Current Settings ");
 	wattrset(statwin, STDATTR);
@@ -281,10 +286,11 @@ void setoptions(void)
 	mvwprintw(statwin, 6, 2, "Activity mode:");
 	mvwprintw(statwin, 7, 2, "MAC addresses:");
 	mvwprintw(statwin, 8, 2, "v6-in-v4 as IPv6:");
-	mvwprintw(statwin, 10, 2, "TCP timeout:");
-	mvwprintw(statwin, 11, 2, "Log interval:");
-	mvwprintw(statwin, 12, 2, "Update interval:");
-	mvwprintw(statwin, 13, 2, "Closed/idle persist:");
+	mvwprintw(statwin, 9, 2, "GeoIP:");
+	mvwprintw(statwin, 12, 2, "TCP timeout:");
+	mvwprintw(statwin, 13, 2, "Log interval:");
+	mvwprintw(statwin, 14, 2, "Update interval:");
+	mvwprintw(statwin, 15, 2, "Closed/idle persist:");
 	showoptions(statwin);
 
 	do {
@@ -315,6 +321,9 @@ void setoptions(void)
 			break;
 		case 8:
 			options.v6inv4asv6 = ~options.v6inv4asv6;
+			break;
+		case 9:
+			options.geoip = ~options.geoip;
 			break;
 		case 10:
 			maketimermenu(&timermenu);
@@ -376,7 +385,7 @@ void setoptions(void)
 		}
 
 		indicatesetting(row, statwin);
-	} while (row != 18);
+	} while (row != 19);
 
 	destroyporttab(&ports);
 	tx_destroymenu(&menu);

--- a/src/options.h
+++ b/src/options.h
@@ -3,7 +3,7 @@
 
 struct OPTIONS {
 	unsigned int color:1, logging:1, revlook:1, servnames:1, promisc:1,
-	    actmode:1, mac:1, v6inv4asv6:1, dummy:8;
+	    actmode:1, mac:1, v6inv4asv6:1, geoip:1, dummy:7;
 	time_t timeout;
 	time_t logspan;
 	time_t updrate;

--- a/src/tcptable.c
+++ b/src/tcptable.c
@@ -21,6 +21,7 @@ tcptable.c - table manipulation routines for the IP monitor
 #include "servname.h"
 #include "hostmon.h"
 #include "sockaddr.h"
+#include "geoip.h"
 
 #define MSGSTRING_MAX	320
 
@@ -375,6 +376,11 @@ struct tcptableent *addentry(struct tcptable *table,
 	memset(new_entry->smacaddr, 0, sizeof(new_entry->smacaddr));
 	memset(new_entry->oth_connection->smacaddr, 0, sizeof(new_entry->oth_connection->smacaddr));
 
+	new_entry->s_country[0] = '\0';
+	new_entry->d_country[0] = '\0';
+	new_entry->oth_connection->s_country[0] = '\0';
+	new_entry->oth_connection->d_country[0] = '\0';
+
 	new_entry->stat = new_entry->oth_connection->stat = 0;
 
 	new_entry->s_fstat = NOTRESOLVED;
@@ -392,6 +398,15 @@ struct tcptableent *addentry(struct tcptable *table,
 	strcpy(new_entry->oth_connection->s_fqdn, new_entry->d_fqdn);
 	new_entry->oth_connection->s_fstat = new_entry->d_fstat;
 	new_entry->oth_connection->d_fstat = new_entry->s_fstat;
+
+if (geoip_is_available()) {
+			if (options.geoip) {
+				geoip_get_country_code(&new_entry->saddr, new_entry->s_country, sizeof(new_entry->s_country));
+				geoip_get_country_code(&new_entry->daddr, new_entry->d_country, sizeof(new_entry->d_country));
+				strcpy(new_entry->oth_connection->d_country, new_entry->s_country);
+				strcpy(new_entry->oth_connection->s_country, new_entry->d_country);
+			}
+		}
 
 	if (new_entry->index < new_entry->oth_connection->index) {
 		new_entry->half_bracket = ACS_ULCORNER;
@@ -792,11 +807,16 @@ void printentry(struct tcptable *table, struct tcptableent *tableentry)
 
 	/* proceed with the actual entry */
 	wattrset(table->tcpscreen, normalattr);
+	char country_buf[8] = "";
+	if (options.geoip && tableentry->s_country[0] != '\0')
+		snprintf(country_buf, sizeof(country_buf), "[%.2s] ", tableentry->s_country);
+
 	mvwprintw(table->tcpscreen,
 		  target_row, 1,
-		  "%.*s:%.*s",
+		  "%s%.*s:%*.*s",
+		  country_buf,
 		  32 * COLS / 80, tableentry->s_fqdn,
-		  10, tableentry->s_sname);
+		  10, 10, tableentry->s_sname);
 
 	wattrset(table->tcpscreen, highattr);
 

--- a/src/tcptable.h
+++ b/src/tcptable.h
@@ -39,8 +39,10 @@ struct tcptableent {
 	int s_fstat;
 	int d_fstat;
 	char smacaddr[18];
-	char s_sname[11];	/* Service names, maxlen=10 */
+	char s_sname[11];
 	char d_sname[11];
+	char s_country[3];
+	char d_country[3];
 	unsigned int protocol;
 	unsigned long pcount;	/* packet count */
 	unsigned long bcount;	/* byte count */


### PR DESCRIPTION
This adds optional real-time country code display (e.g. [US], [DE], [RU]) in
the TCP traffic monitor panel, using the MaxMind GeoLite2-Country database.

Display format: [US] 12.34.56.78:port (country code at the beginning)

Behavior:
  - Disabled by default, enabled via Configure menu (G key)
  - Graceful degradation if DB is missing (no crash, no country codes)
  - Database default path: /usr/share/GeoIP/GeoLite2-Country.mmdb

User requirements:
  - libmaxminddb-dev package installed
  - GeoLite2-Country.mmdb file present at the DB path